### PR TITLE
Update save_email_text to get content from in-use editor, rather than always using tinyMCE

### DIFF
--- a/assets/admin/mkb-admin.js
+++ b/assets/admin/mkb-admin.js
@@ -219,7 +219,12 @@
         close_sidebar_modal(e);
     });
     function save_email_text() {
-        var content = tinyMCE.get('mep_event_cc_email_text').getContent();
+        var content;
+        if (jQuery("#wp-mep_event_cc_email_text-wrap").hasClass('html-active')){
+            content = jQuery('#mep_event_cc_email_text').val()
+        } else {
+            content = tinyMCE.get('mep_event_cc_email_text').getContent();
+        }
         var postID = $('input[name="mep_post_id"]');
         $.ajax({
             url: mp_ajax_url,


### PR DESCRIPTION
Fixes the issue described in #285.

Updates the `save_email_text` function in [assets/admin/mkb-admin.js](https://github.com/magepeopleteam/mage-eventpress/compare/master...k-barber:mage-eventpress:master?expand=1#diff-e941456a6f19e22df3d2e6b7e51cbaa8b57075204c605348818f340bf7e15cc0) to check if the editor is currently on the code editor (indicated by presence of the `html-active` class)

If the editor is current on "Code" mode, it saves the raw text content from that editor. Otherwise, it fetches the tinyMCE content.