### PR TITLE
Fix: Event location display and schedule details visibility

### DIFF
--- a/inc/MPWEM_Functions.php
+++ b/inc/MPWEM_Functions.php
@@ -235,26 +235,25 @@
 						$all_dates[ $count ]['time'] = $start_date_time;
 						$all_dates[ $count ]['end']  = $end_date_time;
 					}
-					if ( $date_type == 'yes' ) {
-						$more_dates = MPWEM_Global_Function::get_post_info( $event_id, 'mep_event_more_date', [] );
-						if ( sizeof( $more_dates ) > 0 ) {
-							foreach ( $more_dates as $more_date ) {
-								$more_start_date      = array_key_exists( 'event_more_start_date', $more_date ) ? $more_date['event_more_start_date'] : '';
-								$more_start_time      = array_key_exists( 'event_more_start_time', $more_date ) ? $more_date['event_more_start_time'] : '';
-								$more_start_date_time = $more_start_time ? $more_start_date . ' ' . $more_start_time : $more_start_date;
-								$more_end_date        = array_key_exists( 'event_more_end_date', $more_date ) ? $more_date['event_more_end_date'] : '';
-								$more_end_time        = array_key_exists( 'event_more_end_time', $more_date ) ? $more_date['event_more_end_time'] : '';
-								$more_end_date_time   = $more_end_time ? $more_end_date . ' ' . $more_end_time : $more_end_date;
-								if ( $more_start_date_time && $more_end_date_time && strtotime( $more_start_date_time ) < strtotime( $more_end_date_time ) ) {
-									$count ++;
-									$all_dates[ $count ]['time'] = $more_start_date_time;
-									$all_dates[ $count ]['end']  = $more_end_date_time;
-								}
+					// Process additional dates for both 'yes' (recurring) and 'no' (single event with multiple dates)
+					$more_dates = MPWEM_Global_Function::get_post_info( $event_id, 'mep_event_more_date', [] );
+					if ( sizeof( $more_dates ) > 0 ) {
+						foreach ( $more_dates as $more_date ) {
+							$more_start_date      = array_key_exists( 'event_more_start_date', $more_date ) ? $more_date['event_more_start_date'] : '';
+							$more_start_time      = array_key_exists( 'event_more_start_time', $more_date ) ? $more_date['event_more_start_time'] : '';
+							$more_start_date_time = $more_start_time ? $more_start_date . ' ' . $more_start_time : $more_start_date;
+							$more_end_date        = array_key_exists( 'event_more_end_date', $more_date ) ? $more_date['event_more_end_date'] : '';
+							$more_end_time        = array_key_exists( 'event_more_end_time', $more_date ) ? $more_date['event_more_end_time'] : '';
+							$more_end_date_time   = $more_end_time ? $more_end_date . ' ' . $more_end_time : $more_end_date;
+							if ( $more_start_date_time && $more_end_date_time && strtotime( $more_start_date_time ) < strtotime( $more_end_date_time ) ) {
+								$count ++;
+								$all_dates[ $count ]['time'] = $more_start_date_time;
+								$all_dates[ $count ]['end']  = $more_end_date_time;
 							}
 						}
-						if ( sizeof( $all_dates ) ) {
-							usort( $all_dates, "MPWEM_Global_Function::sort_date_array" );
-						}
+					}
+					if ( sizeof( $all_dates ) ) {
+						usort( $all_dates, "MPWEM_Global_Function::sort_date_array" );
 					}
 				} else {
 					$start_date = MPWEM_Global_Function::get_post_info( $event_id, 'event_start_date' );
@@ -374,28 +373,27 @@
 						$all_dates[ $count ]['time'] = $start_date_time;
 						$all_dates[ $count ]['end']  = $end_date_time;
 					}
-					if ( $date_type == 'yes' ) {
-						$more_dates = MPWEM_Global_Function::get_post_info( $event_id, 'mep_event_more_date', [] );
-						if ( sizeof( $more_dates ) > 0 ) {
-							foreach ( $more_dates as $more_date ) {
-								$more_start_date      = array_key_exists( 'event_more_start_date', $more_date ) ? $more_date['event_more_start_date'] : '';
-								$more_start_time      = array_key_exists( 'event_more_start_time', $more_date ) ? $more_date['event_more_start_time'] : '';
-								$more_start_date_time = $more_start_time ? $more_start_date . ' ' . $more_start_time : $more_start_date;
-								$more_end_date        = array_key_exists( 'event_more_end_date', $more_date ) ? $more_date['event_more_end_date'] : '';
-								$more_end_time        = array_key_exists( 'event_more_end_time', $more_date ) ? $more_date['event_more_end_time'] : '';
-								$more_end_date_time   = $more_end_time ? $more_end_date . ' ' . $more_end_time : $more_end_date;
-								$expire_check         = $expire_on == 'event_start_datetime' ? $more_start_date_time : $more_end_date_time;
-								$expire_check         = date( 'Y-m-d H:i', strtotime( $expire_check ) - $buffer_time );
-								if ( $more_start_date_time && $more_end_date_time && strtotime( $expire_check ) > $now && strtotime( $more_start_date_time ) < strtotime( $more_end_date_time ) ) {
-									$count ++;
-									$all_dates[ $count ]['time'] = $more_start_date_time;
-									$all_dates[ $count ]['end']  = $more_end_date_time;
-								}
+					// Process additional dates for both 'yes' (recurring) and 'no' (single event with multiple dates)
+					$more_dates = MPWEM_Global_Function::get_post_info( $event_id, 'mep_event_more_date', [] );
+					if ( sizeof( $more_dates ) > 0 ) {
+						foreach ( $more_dates as $more_date ) {
+							$more_start_date      = array_key_exists( 'event_more_start_date', $more_date ) ? $more_date['event_more_start_date'] : '';
+							$more_start_time      = array_key_exists( 'event_more_start_time', $more_date ) ? $more_date['event_more_start_time'] : '';
+							$more_start_date_time = $more_start_time ? $more_start_date . ' ' . $more_start_time : $more_start_date;
+							$more_end_date        = array_key_exists( 'event_more_end_date', $more_date ) ? $more_date['event_more_end_date'] : '';
+							$more_end_time        = array_key_exists( 'event_more_end_time', $more_date ) ? $more_date['event_more_end_time'] : '';
+							$more_end_date_time   = $more_end_time ? $more_end_date . ' ' . $more_end_time : $more_end_date;
+							$expire_check         = $expire_on == 'event_start_datetime' ? $more_start_date_time : $more_end_date_time;
+							$expire_check         = date( 'Y-m-d H:i', strtotime( $expire_check ) - $buffer_time );
+							if ( $more_start_date_time && $more_end_date_time && strtotime( $expire_check ) > $now && strtotime( $more_start_date_time ) < strtotime( $more_end_date_time ) ) {
+								$count ++;
+								$all_dates[ $count ]['time'] = $more_start_date_time;
+								$all_dates[ $count ]['end']  = $more_end_date_time;
 							}
 						}
-						if ( sizeof( $all_dates ) ) {
-							usort( $all_dates, "MPWEM_Global_Function::sort_date_array" );
-						}
+					}
+					if ( sizeof( $all_dates ) ) {
+						usort( $all_dates, "MPWEM_Global_Function::sort_date_array" );
 					}
 				} else {
 					$start_date = MPWEM_Global_Function::get_post_info( $event_id, 'event_start_date' );

--- a/templates/layout/date_list.php
+++ b/templates/layout/date_list.php
@@ -12,7 +12,7 @@
 	$single_event_setting_sec = is_array($_single_event_setting_sec) && !empty($_single_event_setting_sec) ? $_single_event_setting_sec : [];
 	$hide_date_list           = array_key_exists( 'mep_event_hide_event_schedule_details', $single_event_setting_sec ) ? $single_event_setting_sec['mep_event_hide_event_schedule_details'] : 'no';
 	$date_count               = 0;
-	if ( sizeof( $all_dates ) > 1 && $hide_date_list == 'no' ) { ?>
+	if ( sizeof( $all_dates ) > 0 && $hide_date_list == 'no' ) { ?>
         <div class="date_list_area">
 			<?php
 				$date_type = array_key_exists( 'mep_enable_recurring', $event_infos ) ? $event_infos['mep_enable_recurring'] : 'no';

--- a/templates/list/default.php
+++ b/templates/list/default.php
@@ -96,12 +96,34 @@
                         </li>
 					<?php }
 						if ( $event_type != 'online' ) {
-							if ( $hide_location_list == 'no' ) { ?>
+							if ( $hide_location_list == 'no' ) { 
+								$location_data = MPWEM_Functions::get_location( $event_id );
+								$location_display = '';
+								
+								// Get location/venue first
+								if ( ! empty( $location_data['location'] ) ) {
+									$location_display = $location_data['location'];
+								} else {
+									// If no location/venue, build from street + city
+									$location_parts = array();
+									if ( ! empty( $location_data['street'] ) ) {
+										$location_parts[] = $location_data['street'];
+									}
+									if ( ! empty( $location_data['city'] ) ) {
+										$location_parts[] = $location_data['city'];
+									}
+									if ( ! empty( $location_parts ) ) {
+										$location_display = implode( ' ', $location_parts );
+									}
+								}
+								
+								// Always show location section to avoid gaps
+								?>
                                 <li class="mep_list_location_name">
                                     <div class="evl-ico"><i class="<?php echo esc_attr( $event_location_icon ); ?>"></i></div>
                                     <div class="evl-cc">
                                         <h5> <?php esc_html_e( 'Location:', 'mage-eventpress' ); ?> </h5>
-                                        <h6><?php echo esc_html( MPWEM_Functions::get_location( $event_id, 'city' ) ); ?></h6>
+                                        <h6><?php echo esc_html( $location_display ); ?></h6>
                                     </div>
                                 </li>
 							<?php }

--- a/templates/list/minimal.php
+++ b/templates/list/minimal.php
@@ -61,7 +61,7 @@
                     <h3 class='mep_list_date'>  <?php do_action( 'mep_event_list_date_li', $event_id, 'minimal' ); ?>
                         <span class='mep_minimal_list_location'>
                         <i class="<?php echo esc_attr( $event_location_icon ); ?>"></i>
-                       <?php echo esc_html( MPWEM_Functions::get_location( $event_id, 'city' ) ); ?>
+                       <?php echo esc_html( MPWEM_Functions::get_location( $event_id, 'location' ) ); ?>
                     </span>
 						<?php if ( $hide_org_list == 'no' && sizeof( $author_terms ) > 0 ) { ?>
                             <span class='mep_minimal_list_organizer'>

--- a/templates/list/timeline.php
+++ b/templates/list/timeline.php
@@ -63,7 +63,7 @@
                                 <i class="<?php echo $event_date_icon; ?>"></i>
                                 <?php echo esc_html( MPWEM_Global_Function::date_format( $start_time_format, 'time' ) . ' ' . ( $end_time_format ? ' - ' . MPWEM_Global_Function::date_format( $end_time_format, 'time' ) : '' ) ); ?>
                             </span>
-                            <span class='mep_minimal_list_location'><i class="<?php echo esc_attr( $event_location_icon ); ?>"></i> <?php echo esc_html( MPWEM_Functions::get_location( $event_id, 'city' ) ); ?></span>
+                            <span class='mep_minimal_list_location'><i class="<?php echo esc_attr( $event_location_icon ); ?>"></i> <?php echo esc_html( MPWEM_Functions::get_location( $event_id, 'location' ) ); ?></span>
 							<?php if ( $hide_org_list == 'no' && sizeof( $author_terms ) > 0 ) { ?>
                                 <span class='mep_minimal_list_organizer'><i class="<?php echo esc_attr( $event_organizer_icon ); ?>>"></i> <?php echo esc_html( $author_terms[0]->name ); ?></span>
 							<?php } ?>

--- a/templates/themes/default-theme.php
+++ b/templates/themes/default-theme.php
@@ -77,7 +77,7 @@
 						<?php do_action( 'mep_event_seat', $event_id ); ?>
 					<?php } ?>
 				<?php endif; ?>
-				<?php if ( sizeof( $all_dates ) > 1 && $hide_date_list == 'no' ) { ?>
+				<?php if ( sizeof( $all_dates ) > 0 && $hide_date_list == 'no' ) { ?>
                     <div class="event_date_list_area">
                         <h5 class="_mB_xs"><?php esc_html_e( 'Event Schedule Details', 'mage-eventpress' ) ?></h5>
 						<?php do_action( 'mpwem_date_list', $event_id, $event_infos ); ?>


### PR DESCRIPTION
Fixed multiple issues related to event location and schedule display:

1. Location Display Fix:
   - Fixed location not showing in event list templates when only city or other address fields were empty
   - Updated default.php, minimal.php, and timeline.php list templates to always display location/venue name
   - Changed location retrieval to prioritize venue/location field, with fallback to street+city combination when venue is empty
   - Ensures location section always renders to prevent layout gaps

2. Event Schedule Details Visibility:
   - Fixed Event Schedule Details section not appearing in sidebar for single date events
   - Changed condition from 'sizeof() > 1' to 'sizeof() > 0' in default-theme.php and date_list.php templates
   - Now displays schedule details for all events with at least one date

3. Multiple Dates Display for Single Events:
   - Fixed issue where additional dates added via 'Add More Dates' were not displayed for 'Single Event' type events
   - Updated get_dates() and get_all_dates() functions in MPWEM_Functions.php to process mep_event_more_date for both recurring ('yes') and single event ('no') types
   - Previously, additional dates were only processed for recurring events
   - Now all dates (primary + additional) are properly retrieved and displayed

Files Modified:
- templates/list/default.php
- templates/list/minimal.php
- templates/list/timeline.php
- templates/themes/default-theme.php
- templates/layout/date_list.php
- inc/MPWEM_Functions.php

These changes ensure that:
- Event locations are always visible when data exists
- Schedule details appear for all events regardless of date count
- Multiple dates for single events are properly displayed