### PR TITLE
Fix: Handle special characters in ticket type names when adding to cart

### DIFF
--- a/inc/MPWEM_Woocommerce.php
+++ b/inc/MPWEM_Woocommerce.php
@@ -465,10 +465,12 @@
 				$total_price  = 0;
 				if ( sizeof( $names ) > 0 ) {
 					foreach ( $names as $key => $name ) {
-						$current_qty = array_key_exists( $key, $qty ) ? $qty[ $key ] : 0;
-						if ( $name && $current_qty > 0 ) {
-							$ticket_info[ $key ]['ticket_name']  = $name;
-							$ticket_info[ $key ]['ticket_price'] = MPWEM_Functions::get_ticket_price_by_name( $name, $post_id, $ticket_types );
+						// Decode HTML entities and URL encoding to handle special characters
+						$decoded_name = html_entity_decode( urldecode( $name ), ENT_QUOTES | ENT_HTML5, 'UTF-8' );
+						$current_qty = array_key_exists( $key, $qty ) ? (int) $qty[ $key ] : 0;
+						if ( $decoded_name && $current_qty > 0 ) {
+							$ticket_info[ $key ]['ticket_name']  = $decoded_name;
+							$ticket_info[ $key ]['ticket_price'] = MPWEM_Functions::get_ticket_price_by_name( $decoded_name, $post_id, $ticket_types );
 							$ticket_info[ $key ]['ticket_qty']   = $current_qty;
 							$ticket_info[ $key ]['max_qty']      = array_key_exists( $key, $max_qty ) ? $max_qty[ $key ] : 0;
 							$ticket_info[ $key ]['event_date']   = $start_date;


### PR DESCRIPTION
Issue: When ticket types contain special characters (parentheses, umlauts, etc.), the quantity was being set to 0 when adding items to cart.

Root Cause:
- Ticket names with special characters were being HTML/URL encoded during form submission
- The matching logic wasn't properly decoding these encoded values
- The mep_get_orginal_ticket_name() function was incorrectly splitting on underscores

Changes Made:
1. Updated mep_get_orginal_ticket_name() to properly decode HTML entities and URL encoding
   - Only splits on underscore if it's a compound key pattern (name_123)
   - Otherwise uses the full decoded ticket name

2. Enhanced mep_get_ticket_type_price_by_name() with proper normalization
   - Decodes and normalizes ticket names before comparison
   - Uses normalized comparison to handle encoding differences
   - Exits loop early when match is found for better performance

3. Fixed mep_cart_ticket_type() to decode ticket names from POST data
   - Properly decodes all ticket names before processing
   - Ensures quantity is cast to integer to prevent type issues
   - Uses decoded names consistently throughout the function

4. Updated MPWEM_Functions::get_ticket_price_by_name()
   - Decodes and normalizes ticket names for proper matching
   - Uses normalized comparison for encoding differences
   - Exits loop early when match is found

5. Enhanced MPWEM_Woocommerce::get_cart_ticket_info()
   - Decodes ticket names from POST data
   - Ensures quantity is properly cast to integer

Result: Ticket types with special characters (e.g., 'Paar-Ticket (2Pers. für 3h)') now correctly preserve quantity when adding to cart.

Files Modified:
- inc/mep_functions.php
- inc/MPWEM_Functions.php
- inc/MPWEM_Woocommerce.php