### PR TITLE
Fix expired event shortcodes for recurring events

### DIFF
--- a/inc/MPWEM_Query.php
+++ b/inc/MPWEM_Query.php
@@ -41,7 +41,11 @@
 			public static function event_query( $show, $sort = '', $cat = '', $org = '', $city = '', $country = '', $evnt_type = 'upcoming', $state = '', $year = '', $paged_override = 0, $tag = '' ) {
 				$event_expire_on_old = mep_get_option( 'mep_event_expire_on_datetimes', 'general_setting_sec', 'event_start_datetime' );
 				$event_order_by      = mep_get_option( 'mep_event_list_order_by', 'general_setting_sec', 'meta_value' );
-				$event_expire_on     = $event_expire_on_old == 'event_end_datetime' ? 'event_end_datetime' : 'event_upcoming_datetime';
+				if ( $event_expire_on_old === 'event_end_datetime' || $event_expire_on_old === 'event_expire_datetime' ) {
+					$event_expire_on = 'event_expire_datetime';
+				} else {
+					$event_expire_on = 'event_upcoming_datetime';
+				}
 				$now                 = current_time( 'Y-m-d H:i:s' );
 				if ( $paged_override && is_numeric( $paged_override ) ) {
 					$paged = intval( $paged_override );
@@ -169,12 +173,50 @@
 					);
 				}
 
-				$expire_filter = ! empty( $event_expire_on ) ? array(
-					'key'     => $event_expire_on,
-					'value'   => $now,
-					'compare' => $etype,
-					'type'    => 'DATETIME'
-				) : '';
+				$expire_filter = '';
+				if ( ! empty( $event_expire_on ) ) {
+					if ( $event_expire_on === 'event_upcoming_datetime' ) {
+						// Some selected-date recurring events never get event_upcoming_datetime populated.
+						// In that case fall back to the saved start datetime so expired events still appear.
+						$expire_filter = array(
+							'relation' => 'OR',
+							array(
+								'key'     => 'event_upcoming_datetime',
+								'value'   => $now,
+								'compare' => $etype,
+								'type'    => 'DATETIME'
+							),
+							array(
+								'relation' => 'AND',
+								array(
+									'relation' => 'OR',
+									array(
+										'key'     => 'event_upcoming_datetime',
+										'compare' => 'NOT EXISTS'
+									),
+									array(
+										'key'     => 'event_upcoming_datetime',
+										'value'   => '',
+										'compare' => '='
+									)
+								),
+								array(
+									'key'     => 'event_start_datetime',
+									'value'   => $now,
+									'compare' => $etype,
+									'type'    => 'DATETIME'
+								)
+							)
+						);
+					} else {
+						$expire_filter = array(
+							'key'     => $event_expire_on,
+							'value'   => $now,
+							'compare' => $etype,
+							'type'    => 'DATETIME'
+						);
+					}
+				}
 
 				// Build meta_query
 				$meta_query = array();

--- a/inc/MPWEM_Shortcodes.php
+++ b/inc/MPWEM_Shortcodes.php
@@ -11,6 +11,7 @@
 			public function __construct() {
 				add_shortcode( 'event-list-recurring', array( $this, 'eventlistrecurring' ) );
 				add_shortcode( 'event-list', array( $this, 'event_list' ) );
+				add_shortcode( 'expire-event-list', array( $this, 'expired_event_list' ) );
 				add_shortcode( 'event-add-cart-section', array( $this, 'add_to_cart_section' ) );
 				add_shortcode( 'event-city-list', array( $this, 'event_city_list' ) );
 				add_shortcode( 'event-speaker-list', array( $this, 'speaker_list' ) );
@@ -19,6 +20,11 @@
             public function eventlistrecurring( $atts, $content = null ) {
 	            return $this->event_list( $atts, $content );
             }
+			public function expired_event_list( $atts, $content = null ) {
+				$atts           = is_array( $atts ) ? $atts : array();
+				$atts['status'] = 'expired';
+				return $this->event_list( $atts, $content );
+			}
 			public function event_list( $atts, $content = null ) {
 				$defaults         = array(
 					"cat"              => "0",


### PR DESCRIPTION
Register the documented [expire-event-list] shortcode as an alias of the main event list shortcode with status forced to expired.

Normalize the event expiry setting so both event_end_datetime and event_expire_datetime map to the saved event_expire_datetime meta key.

When the site is configured to expire events by start time, allow expired queries to fall back from event_upcoming_datetime to event_start_datetime for events where event_upcoming_datetime is empty. This fixes selected-date recurring events that appear as expired in the admin dashboard but were omitted from front-end expired event shortcodes.