### PR TITLE
Fix by Shahnur -- calendar settings tabbed admin UI and 2026-05-06 02:32

### DIFF
--- a/assets/admin/calendar-admin.css
+++ b/assets/admin/calendar-admin.css
@@ -45,28 +45,84 @@
 	box-shadow: 0 6px 18px rgba(0, 44, 102, 0.08);
 }
 
-.mep-cal-settings-section {
+.mep-cal-settings-tabs {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 8px;
 	margin: 0;
+	padding: 18px 22px;
+	background: #fff;
 	border-bottom: 1px solid var(--mep-cal-admin-gray);
+}
+
+.mep-cal-settings-tab {
+	min-height: 38px;
+	margin: 0;
+	padding: 8px 14px;
+	border: 1px solid #c8d1dc;
+	border-radius: 4px;
+	background: var(--mep-cal-admin-theme-soft);
+	color: var(--mep-cal-admin-dark);
+	font-size: 13px;
+	font-weight: 600;
+	line-height: 1.35;
+	cursor: pointer;
+	box-shadow: none;
+}
+
+.mep-cal-settings-tab:hover,
+.mep-cal-settings-tab:focus {
+	border-color: var(--mep-cal-admin-theme);
+	color: var(--mep-cal-admin-theme);
+	outline: none;
+	box-shadow: 0 0 0 1px var(--mep-cal-admin-theme);
+}
+
+.mep-cal-settings-tab.is-active {
+	background: var(--mep-cal-admin-theme);
+	border-color: var(--mep-cal-admin-theme);
+	color: var(--mep-cal-admin-white);
+}
+
+.mep-cal-settings-section {
+	margin: 18px 22px 24px;
+	border: 1px solid #e5e7eb;
+	border-radius: 10px;
+	display: none;
+	padding: 20px 20px 22px;
+	background: #fff;
+	box-shadow: 0 3px 12px rgba(15, 23, 42, 0.04);
+}
+
+.mep-cal-settings-section.is-active {
+	display: block;
 }
 
 .mep-cal-settings-section:last-of-type {
-	border-bottom: 0;
+	margin-bottom: 24px;
 }
 
 .mep-cal-settings-section h2 {
-	margin: 0;
-	padding: 16px 22px;
-	background: var(--mep-cal-admin-theme-soft);
+	margin: 0 0 16px;
+	padding: 0 0 12px;
+	background: transparent;
 	color: var(--mep-cal-admin-theme);
 	font-size: 18px;
 	font-weight: 600;
-	border-bottom: 1px solid var(--mep-cal-admin-gray);
+	line-height: 1.35;
+	border: 0;
+	border-bottom: 1px solid #e5e7eb;
+	box-shadow: none;
 }
 
 .mep-cal-settings-section .form-table {
 	margin: 0;
+	width: 100%;
 	border-collapse: collapse;
+	border: 1px solid #e5e7eb;
+	border-radius: 8px;
+	overflow: hidden;
+	background: #fff;
 }
 
 .mep-cal-settings-section .form-table th,
@@ -351,9 +407,26 @@
 		padding-right: 16px;
 	}
 
+	.mep-cal-settings-tabs {
+		padding-left: 16px;
+		padding-right: 16px;
+	}
+
+	.mep-cal-settings-tab {
+		flex: 1 1 140px;
+		justify-content: center;
+	}
+
 	.mep-cal-settings-section h2,
 	.mep-cal-shortcode-ref,
 	.mep-calendar-settings-wrap form p.submit {
+		padding-left: 16px;
+		padding-right: 16px;
+	}
+
+	.mep-cal-settings-section {
+		margin-left: 16px;
+		margin-right: 16px;
 		padding-left: 16px;
 		padding-right: 16px;
 	}

--- a/assets/admin/calendar-admin.js
+++ b/assets/admin/calendar-admin.js
@@ -28,7 +28,30 @@ jQuery(document).ready(function($) {
         refreshRulePreview($row);
     }
 
+    function activateSettingsTab($tab) {
+        var targetId = $tab.data('tab-target');
+
+        if (!targetId) {
+            return;
+        }
+
+        $('.mep-cal-settings-tab').removeClass('is-active').attr('aria-selected', 'false');
+        $('.mep-cal-settings-section[role="tabpanel"]').removeClass('is-active').attr('hidden', true);
+
+        $tab.addClass('is-active').attr('aria-selected', 'true');
+        $('#' + targetId).addClass('is-active').removeAttr('hidden');
+    }
+
     initColorPickers(document);
+
+    $(document).on('click', '.mep-cal-settings-tab', function(e) {
+        e.preventDefault();
+        activateSettingsTab($(this));
+    });
+
+    $('.mep-cal-settings-tabs .mep-cal-settings-tab.is-active').first().each(function() {
+        activateSettingsTab($(this));
+    });
 
     $(document).on('change', '.mep-cal-day-rule-type', function() {
         bindRuleRow($(this).closest('.mep-cal-day-rule-item'));

--- a/inc/MPWEM_Calendar.php
+++ b/inc/MPWEM_Calendar.php
@@ -1591,8 +1591,20 @@ if ( ! class_exists( 'MPWEM_Calendar_Settings' ) ) {
 				<form method="post" action="options.php">
 					<?php settings_fields( 'mep_calendar_settings_group' ); ?>
 
+					<?php // Fixed by Shahnur — calendar settings tab layout and 2026-05-06 02:20 PM (Asia/Dhaka) ?>
+					<div class="mep-cal-settings-tabs" role="tablist" aria-label="<?php esc_attr_e( 'Calendar settings sections', 'mage-eventpress' ); ?>">
+						<button type="button" class="mep-cal-settings-tab is-active" id="mep-cal-tab-general" data-tab-target="mep-cal-panel-general" role="tab" aria-selected="true" aria-controls="mep-cal-panel-general"><?php esc_html_e( 'General', 'mage-eventpress' ); ?></button>
+						<button type="button" class="mep-cal-settings-tab" id="mep-cal-tab-navigation" data-tab-target="mep-cal-panel-navigation" role="tab" aria-selected="false" aria-controls="mep-cal-panel-navigation"><?php esc_html_e( 'Navigation', 'mage-eventpress' ); ?></button>
+						<button type="button" class="mep-cal-settings-tab" id="mep-cal-tab-expired" data-tab-target="mep-cal-panel-expired" role="tab" aria-selected="false" aria-controls="mep-cal-panel-expired"><?php esc_html_e( 'Expired Events', 'mage-eventpress' ); ?></button>
+						<button type="button" class="mep-cal-settings-tab" id="mep-cal-tab-colors" data-tab-target="mep-cal-panel-colors" role="tab" aria-selected="false" aria-controls="mep-cal-panel-colors"><?php esc_html_e( 'Colors', 'mage-eventpress' ); ?></button>
+						<button type="button" class="mep-cal-settings-tab" id="mep-cal-tab-weekdays" data-tab-target="mep-cal-panel-weekdays" role="tab" aria-selected="false" aria-controls="mep-cal-panel-weekdays"><?php esc_html_e( 'Weekdays', 'mage-eventpress' ); ?></button>
+						<button type="button" class="mep-cal-settings-tab" id="mep-cal-tab-backgrounds" data-tab-target="mep-cal-panel-backgrounds" role="tab" aria-selected="false" aria-controls="mep-cal-panel-backgrounds"><?php esc_html_e( 'Backgrounds', 'mage-eventpress' ); ?></button>
+						<button type="button" class="mep-cal-settings-tab" id="mep-cal-tab-stock" data-tab-target="mep-cal-panel-stock" role="tab" aria-selected="false" aria-controls="mep-cal-panel-stock"><?php esc_html_e( 'Stock', 'mage-eventpress' ); ?></button>
+						<button type="button" class="mep-cal-settings-tab" id="mep-cal-tab-shortcode" data-tab-target="mep-cal-panel-shortcode" role="tab" aria-selected="false" aria-controls="mep-cal-panel-shortcode"><?php esc_html_e( 'Shortcode', 'mage-eventpress' ); ?></button>
+					</div>
+
 					<!-- General Settings -->
-					<div class="mep-cal-settings-section">
+					<div class="mep-cal-settings-section is-active" id="mep-cal-panel-general" role="tabpanel" aria-labelledby="mep-cal-tab-general">
 						<h2><?php esc_html_e( 'General Settings', 'mage-eventpress' ); ?></h2>
 						<table class="form-table">
 							<tr>
@@ -1679,7 +1691,7 @@ if ( ! class_exists( 'MPWEM_Calendar_Settings' ) ) {
 					</div>
 
 					<!-- Navigation Settings -->
-					<div class="mep-cal-settings-section">
+					<div class="mep-cal-settings-section" id="mep-cal-panel-navigation" role="tabpanel" aria-labelledby="mep-cal-tab-navigation" hidden>
 						<h2><?php esc_html_e( 'Navigation Settings', 'mage-eventpress' ); ?></h2>
 						<table class="form-table">
 							<tr>
@@ -1706,7 +1718,7 @@ if ( ! class_exists( 'MPWEM_Calendar_Settings' ) ) {
 					</div>
 
 					<!-- Expired Events Settings -->
-					<div class="mep-cal-settings-section">
+					<div class="mep-cal-settings-section" id="mep-cal-panel-expired" role="tabpanel" aria-labelledby="mep-cal-tab-expired" hidden>
 						<h2><?php esc_html_e( 'Expired Event Settings', 'mage-eventpress' ); ?></h2>
 						<table class="form-table">
 							<tr>
@@ -1749,7 +1761,7 @@ if ( ! class_exists( 'MPWEM_Calendar_Settings' ) ) {
 					</div>
 
 					<!-- Color Settings -->
-					<div class="mep-cal-settings-section">
+					<div class="mep-cal-settings-section" id="mep-cal-panel-colors" role="tabpanel" aria-labelledby="mep-cal-tab-colors" hidden>
 						<h2><?php esc_html_e( 'Color Settings', 'mage-eventpress' ); ?></h2>
 						<table class="form-table">
 							<tr>
@@ -1780,7 +1792,7 @@ if ( ! class_exists( 'MPWEM_Calendar_Settings' ) ) {
 					</div>
 
 					<!-- Weekday Column Styles -->
-					<div class="mep-cal-settings-section">
+					<div class="mep-cal-settings-section" id="mep-cal-panel-weekdays" role="tabpanel" aria-labelledby="mep-cal-tab-weekdays" hidden>
 						<h2><?php esc_html_e( 'Weekday Column Styles', 'mage-eventpress' ); ?></h2>
 						<table class="form-table">
 							<?php foreach ( $this->get_weekday_labels() as $weekday_key => $weekday_label ) : ?>
@@ -1808,7 +1820,7 @@ if ( ! class_exists( 'MPWEM_Calendar_Settings' ) ) {
 					</div>
 
 					<!-- Day Background Images -->
-					<div class="mep-cal-settings-section">
+					<div class="mep-cal-settings-section" id="mep-cal-panel-backgrounds" role="tabpanel" aria-labelledby="mep-cal-tab-backgrounds" hidden>
 						<h2><?php esc_html_e( 'Day Background Images', 'mage-eventpress' ); ?></h2>
 						<table class="form-table">
 							<tr>
@@ -1849,7 +1861,7 @@ if ( ! class_exists( 'MPWEM_Calendar_Settings' ) ) {
 					</div>
 
 					<!-- Stock Color Settings -->
-					<div class="mep-cal-settings-section">
+					<div class="mep-cal-settings-section" id="mep-cal-panel-stock" role="tabpanel" aria-labelledby="mep-cal-tab-stock" hidden>
 						<h2><?php esc_html_e( 'Stock Indicator Colors', 'mage-eventpress' ); ?></h2>
 						<table class="form-table">
 							<tr>
@@ -1871,7 +1883,7 @@ if ( ! class_exists( 'MPWEM_Calendar_Settings' ) ) {
 					</div>
 
 					<!-- Shortcode Reference -->
-					<div class="mep-cal-settings-section">
+					<div class="mep-cal-settings-section" id="mep-cal-panel-shortcode" role="tabpanel" aria-labelledby="mep-cal-tab-shortcode" hidden>
 						<h2><?php esc_html_e( 'Shortcode Reference', 'mage-eventpress' ); ?></h2>
 						<div class="mep-cal-shortcode-ref">
 							<code>[mep-event-calendar]</code>


### PR DESCRIPTION


Issue: The Event Calendar Settings page was visually crowded because all sections lived in one long form, and the active section header still sat too tightly under the tab row after the first admin styling pass.
Resolution: Converted the existing settings sections into tab panels, added scoped admin tab-switching behavior, and refined the section spacing/title treatment so the page reads as separate panels without changing any option keys, hooks, or save behavior.

Details:
- Added tab buttons and accessible tabpanel markup in MPWEM_Calendar.php.
- Kept the existing options.php submission flow and mep_calendar_settings field structure intact.
- Added admin JS to activate tabs and toggle the matching settings panel only.
- Updated admin CSS for tab presentation, panel spacing, responsive layout, and cleaner section title separation.
- Preserved the day background rule UI and all existing settings inputs.

Validation:
- PHP lint passed with C:\wamp64\bin\php\php8.2.29\php.exe -l inc\MPWEM_Calendar.php.
- node --check passed for assets\admin\calendar-admin.js.
- git diff --check passed apart from normal CRLF warnings in the Windows worktree.