### PR TITLE
Fix: calendar Week/Day view causes browser 'page unresponsive' crash

### DIFF
--- a/assets/helper/calendar/calendar.js
+++ b/assets/helper/calendar/calendar.js
@@ -507,7 +507,7 @@
             allDayText: getLocaleUiText(locale, 'allDay', mepCalendar.i18n.allDay),
             editable: false,
             selectable: false,
-            expandRows: true,
+            expandRows: false,
             dayMaxEvents: true,
             navLinks: true,
             eventDisplay: 'block',
@@ -564,8 +564,9 @@
             },
 
             eventsSet: function(events) {
-                renderTimeGridDaySummaryButtons($el, calId, events);
+                var eventsSnapshot = events ? events.slice() : [];
                 setTimeout(function() {
+                    renderTimeGridDaySummaryButtons($el, calId, eventsSnapshot);
                     if (calendars[calId]) {
                         styleMonthMoreLinks($el);
                         localizeCalendarChrome(calendars[calId], locale);
@@ -784,14 +785,33 @@
     }
 
     /**
+     * Strip timezone and time from FullCalendar ISO 8601 strings.
+     * Week/Day views send strings like "2026-05-11T00:00:00+06:00".
+     * We send only plain "Y-m-d" to PHP to avoid strtotime() inconsistencies on live servers.
+     *
+     * @param {string} isoStr FullCalendar date string.
+     * @returns {string} Plain date YYYY-MM-DD, or original string if not ISO 8601.
+     */
+    function stripIsoTimezone(isoStr) {
+        if (typeof isoStr !== 'string' || !isoStr) {
+            return isoStr || '';
+        }
+        var match = isoStr.match(/^(\d{4}-\d{2}-\d{2})[T ]/);
+        if (match) {
+            return match[1];
+        }
+        return isoStr;
+    }
+
+    /**
      * Load events via AJAX
      */
     function loadEvents($el, calId, info, successCallback, failureCallback) {
         var data = {
             action: 'mep_calendar_get_events',
             nonce: mepCalendar.nonce,
-            visible_start: info && info.startStr ? info.startStr : '',
-            visible_end: info && info.endStr ? info.endStr : '',
+            visible_start: info && info.startStr ? stripIsoTimezone(info.startStr) : '',
+            visible_end: info && info.endStr ? stripIsoTimezone(info.endStr) : '',
             view_type: info && info.view && info.view.type ? info.view.type : '',
             cat: $el.data('cat') || '',
             org: $el.data('org') || '',
@@ -852,6 +872,7 @@
             type: 'POST',
             data: data,
             dataType: 'json',
+            timeout: 30000,
             success: function(response) {
                 if (response.success && response.data) {
                     successCallback(response.data);
@@ -860,7 +881,7 @@
                 }
             },
             error: function() {
-                failureCallback();
+                successCallback([]);
             }
         });
     }

--- a/inc/MPWEM_Calendar.php
+++ b/inc/MPWEM_Calendar.php
@@ -565,6 +565,8 @@ if ( ! class_exists( 'MPWEM_Calendar_Ajax' ) ) {
 		public function get_events() {
 			check_ajax_referer( 'mep_calendar_nonce', 'nonce' );
 
+			@set_time_limit( 25 );
+
 			$cat             = isset( $_POST['cat'] ) ? sanitize_text_field( wp_unslash( $_POST['cat'] ) ) : '';
 			$org             = isset( $_POST['org'] ) ? sanitize_text_field( wp_unslash( $_POST['org'] ) ) : '';
 			$tag             = isset( $_POST['tag'] ) ? sanitize_text_field( wp_unslash( $_POST['tag'] ) ) : '';
@@ -583,6 +585,11 @@ if ( ! class_exists( 'MPWEM_Calendar_Ajax' ) ) {
 			$visible_start   = isset( $_POST['visible_start'] ) ? sanitize_text_field( wp_unslash( $_POST['visible_start'] ) ) : '';
 			$visible_end     = isset( $_POST['visible_end'] ) ? sanitize_text_field( wp_unslash( $_POST['visible_end'] ) ) : '';
 			$view_type       = isset( $_POST['view_type'] ) ? sanitize_text_field( wp_unslash( $_POST['view_type'] ) ) : '';
+
+			// Sanitize ISO 8601 datetime strings from FullCalendar (e.g. "2026-05-11T00:00:00+06:00")
+			// These may fail on some live server PHP configs — strip to plain Y-m-d date.
+			$visible_start = $this->normalize_fullcalendar_datestr( $visible_start );
+			$visible_end   = $this->normalize_fullcalendar_datestr( $visible_end );
 
 			$show_stock      = isset( $_POST['show_stock_details'] ) ? sanitize_text_field( wp_unslash( $_POST['show_stock_details'] ) ) : 'no';
 			$hide_time       = isset( $_POST['hide_time'] ) ? sanitize_text_field( wp_unslash( $_POST['hide_time'] ) ) : 'no';
@@ -1139,11 +1146,47 @@ if ( ! class_exists( 'MPWEM_Calendar_Ajax' ) ) {
 			if ( empty( $value ) ) {
 				return '';
 			}
-			$timestamp = strtotime( $value );
-			if ( false === $timestamp ) {
+
+			// Strip timezone offset from ISO 8601 strings like "2026-05-11T00:00:00+06:00"
+			// before passing to strtotime(), which can behave inconsistently on live servers.
+			$clean = preg_replace( '/[Tt](\d{2}:\d{2}:\d{2})([+-]\d{2}:?\d{2}|Z)?$/', '', trim( $value ) );
+			if ( empty( $clean ) ) {
+				$clean = $value;
+			}
+
+			$timestamp = strtotime( $clean );
+			if ( false === $timestamp || 0 === $timestamp ) {
+				// Fallback: try the original value as-is
+				$timestamp = strtotime( $value );
+			}
+			if ( false === $timestamp || 0 === $timestamp ) {
 				return '';
 			}
-			return 'end' === $boundary ? date( 'Y-m-d', $timestamp ) : date( 'Y-m-d', $timestamp );
+			return date( 'Y-m-d', $timestamp );
+		}
+
+		/**
+		 * Normalize a FullCalendar datetime string to a plain Y-m-d date.
+		 * FullCalendar Week/Day views send strings like "2026-05-11T00:00:00+06:00".
+		 * On some live server PHP configs, strtotime() with a timezone offset can
+		 * return wrong results or false. We strip the time+timezone part and keep only the date.
+		 *
+		 * @param string $value Raw datetime string from JS.
+		 * @return string Plain Y-m-d date string, or the original value if it is already plain.
+		 */
+		private function normalize_fullcalendar_datestr( $value ) {
+			$value = trim( (string) $value );
+			if ( empty( $value ) ) {
+				return '';
+			}
+
+			// If the string contains a T (ISO 8601 datetime), extract only the date part.
+			if ( preg_match( '/^(\d{4}-\d{2}-\d{2})[Tt]/', $value, $matches ) ) {
+				return $matches[1];
+			}
+
+			// Already looks like a plain date or something else — return as-is.
+			return $value;
 		}
 
 		private function parse_event_ids( $value ) {
@@ -1183,12 +1226,15 @@ if ( ! class_exists( 'MPWEM_Calendar_Ajax' ) ) {
 				return $instances;
 			}
 
-			$current_day = strtotime( date( 'Y-m-d', strtotime( $start_dt ) ) );
-			$final_day   = strtotime( date( 'Y-m-d', strtotime( $end_dt ) ) );
-			$start_day   = date( 'Y-m-d', strtotime( $start_dt ) );
-			$end_day     = date( 'Y-m-d', strtotime( $end_dt ) );
+			$current_day       = strtotime( date( 'Y-m-d', strtotime( $start_dt ) ) );
+			$final_day         = strtotime( date( 'Y-m-d', strtotime( $end_dt ) ) );
+			$start_day         = date( 'Y-m-d', strtotime( $start_dt ) );
+			$end_day           = date( 'Y-m-d', strtotime( $end_dt ) );
+			$split_iter_limit  = 500;
+			$split_iter_count  = 0;
 
-			while ( false !== $current_day && $current_day <= $final_day ) {
+			while ( false !== $current_day && $current_day <= $final_day && $split_iter_count < $split_iter_limit ) {
+				$split_iter_count++;
 				$current_date  = date( 'Y-m-d', $current_day );
 				$segment_start = $current_date === $start_day ? $start_dt : $current_date . ' 00:00:00';
 				$segment_end   = $current_date === $end_day ? $end_dt : $current_date . ' 23:59:59';
@@ -1300,7 +1346,10 @@ if ( ! class_exists( 'MPWEM_Calendar_Ajax' ) ) {
 					}
 
 					$current_timestamp = $window_start;
-					while ( $current_timestamp <= $window_end ) {
+					$iteration_limit   = 1500;
+					$iteration_count   = 0;
+					while ( $current_timestamp !== false && $current_timestamp <= $window_end && $iteration_count < $iteration_limit ) {
+						$iteration_count++;
 						$date = date( 'Y-m-d', $current_timestamp );
 						$day  = strtolower( date( 'D', $current_timestamp ) );
 						if ( ! in_array( $date, $off_dates, true ) && ! in_array( $day, $off_days, true ) ) {


### PR DESCRIPTION
## Root Cause

Clicking the Week or Day tab triggered `renderTimeGridDaySummaryButtons()` synchronously inside FullCalendar's `eventsSet` callback. This function iterates every time-grid column, queries all events per column, and manipulates the DOM — all on the JS main thread in one blocking burst. Month view was immune because `renderTimeGridDaySummaryButtons` exits immediately for `dayGridMonth`. With a moderate number of events the synchronous block exceeded Chrome's 'page unresponsive' threshold, freezing/crashing the browser tab.

## Changes

### assets/helper/calendar/calendar.js

1. **eventsSet callback — primary fix** `renderTimeGridDaySummaryButtons` was called synchronously before the existing `setTimeout`. Moved it inside the `setTimeout(..., 0)` block so execution is deferred until after the browser repaints, releasing the main thread between FullCalendar's render and the summary-button injection. Events array is snapshot via `.slice()` first so the async callback works on a stable copy.

   Before: eventsSet: function(events) { renderTimeGridDaySummaryButtons($el, calId, events); // BLOCKING setTimeout(function() { ... }, 0); }

   After: eventsSet: function(events) { var eventsSnapshot = events ? events.slice() : []; setTimeout(function() { renderTimeGridDaySummaryButtons($el, calId, eventsSnapshot); ... }, 0); }

2. **expandRows changed from true → false** Prevents FullCalendar timeGrid from stretching rows to fill the viewport height, which can trigger a ResizeObserver feedback loop when combined with dynamic DOM injection.

3. **stripIsoTimezone() helper added** Strips the time+timezone portion from FullCalendar ISO 8601 date strings (e.g. "2026-05-11T00:00:00+06:00") before sending to PHP via AJAX. Week/Day views send full ISO strings; PHP strtotime() on some shared cPanel hosts returns wrong results or false for strings with timezone offsets, causing the date range filter to silently return zero events (empty calendar) instead of the correct week.

4. **AJAX timeout set to 30 000 ms** Prevents the browser from hanging indefinitely on slow shared hosting. Previously there was no timeout.

5. **AJAX error handler changed to successCallback([])** Replaced `failureCallback()` with `successCallback([])` so a network or server error shows an empty calendar instead of a FullCalendar error state that can cascade into further re-fetches.

### inc/MPWEM_Calendar.php

1. **normalize_fullcalendar_datestr() method added** Strips the time+timezone from ISO 8601 strings at the PHP entry point. Belt-and-suspenders complement to the JS strip above.

2. **set_time_limit(25) in get_events()** Caps PHP execution for the AJAX handler at 25 s on shared cPanel hosts where the default limit may be 30 s or unlimited, preventing Apache worker exhaustion on slow queries.

3. **normalize_date_boundary() hardened** Now strips timezone offset before passing to strtotime(), adds a zero-timestamp guard, and falls back to the original string if the stripped version produces an empty result.

4. **build_event_instances() split loop — iteration cap added** Added $split_iter_limit = 500 guard to the while loop that splits multi-day events into per-day segments for month view. Without this cap a multi-year event could generate 1000+ segment instances per AJAX call, bloating the JSON response and exhausting PHP memory. 500 days covers any realistic visible calendar window.

5. **get_repeated_dates_for_range() iteration cap added** Added $iteration_limit = 1500 guard to the everyday-recurring event date expansion loop. Prevents unbounded iteration if the event spans many years or the strtotime('+N day') call misbehaves on the server.