### PR TITLE
Fix calendar event click: carry clicked date and block expired occurrences

### DIFF
--- a/assets/frontend/mpwem_style.css
+++ b/assets/frontend/mpwem_style.css
@@ -9,6 +9,8 @@
 	}
 	.reg_close_msg {background-color: #fffaec; color: #d32f2f; border-left: 5px solid #d32f2f; padding: 15px 20px; margin: 20px 0; border-radius: 4px; font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif; font-size: 16px; font-weight: 500; display: flex; align-items: center; box-shadow: 0 2px 5px rgba(0,0,0,0.05); }
 	.reg_close_msg { animation: fadeIn 0.5s ease-in-out; }
+	.mpwem_date_expired_msg._margin_zero_text_center { background-color: #fffaec; border-left: 5px solid #d32f2f; padding: 18px 24px; margin: 20px 0; border-radius: 6px; text-align: center; box-shadow: 0 2px 6px rgba(0,0,0,0.06); animation: fadeIn 0.5s ease-in-out; }
+	.mpwem_date_expired_msg ._text_theme { color: #d32f2f; font-size: 16px; font-weight: 600; line-height: 1.6; }
 	@keyframes fadeIn {from { opacity: 0; transform: translateY(-10px); }to { opacity: 1; transform: translateY(0); }}
 
 	div.mpwem_related_area.on_load_off{

--- a/inc/MPWEM_Calendar.php
+++ b/inc/MPWEM_Calendar.php
@@ -1058,6 +1058,10 @@ if ( ! class_exists( 'MPWEM_Calendar_Ajax' ) ) {
 			$fc_start = date( 'Y-m-d\TH:i:s', strtotime( $start_dt ) );
 			$fc_end   = date( 'Y-m-d\TH:i:s', strtotime( $end_dt ) );
 
+			// Fixed by Shahnur — carry the clicked instance date to the event page so the
+			// correct date is pre-selected and its expired/booking state is reflected.
+			$event_url = $this->append_date_to_url( $url, $start_dt );
+
 			$all_day = false;
 			if ( class_exists( 'MPWEM_Global_Function' ) ) {
 				$all_day = ! MPWEM_Global_Function::check_time_exit_date( $start_dt );
@@ -1076,7 +1080,7 @@ if ( ! class_exists( 'MPWEM_Calendar_Ajax' ) ) {
 				'title'           => $normalized_title,
 				'start'           => $fc_start,
 				'end'             => $fc_end,
-				'url'             => $url,
+				'url'             => $event_url,
 				'backgroundColor' => $bg_color,
 				'borderColor'     => $bg_color,
 				'textColor'       => $text_color,
@@ -1187,6 +1191,28 @@ if ( ! class_exists( 'MPWEM_Calendar_Ajax' ) ) {
 
 			// Already looks like a plain date or something else — return as-is.
 			return $value;
+		}
+
+		/**
+		 * Append the specific instance date to an event permalink as a `date` query arg.
+		 * The single-event page and the ticket date selector both read $_GET['date'] as a
+		 * Unix timestamp to pick the active date instance, so we pass the instance start time.
+		 *
+		 * @param string $url      Event permalink.
+		 * @param string $start_dt Instance start datetime (Y-m-d H:i:s or Y-m-d).
+		 * @return string URL with the date query arg appended.
+		 */
+		private function append_date_to_url( $url, $start_dt ) {
+			if ( empty( $url ) ) {
+				return $url;
+			}
+
+			$timestamp = strtotime( $start_dt );
+			if ( ! $timestamp ) {
+				return $url;
+			}
+
+			return add_query_arg( 'date', $timestamp, $url );
 		}
 
 		private function parse_event_ids( $value ) {

--- a/templates/layout/registration_content.php
+++ b/templates/layout/registration_content.php
@@ -30,10 +30,37 @@
     $all_times   = MPWEM_Functions::get_times( $event_id, $all_dates, $url_date );
 	$upcoming_date            = is_array($event_infos) && array_key_exists( 'event_upcoming_datetime', $event_infos ) && $event_recurring == 'no' && array_key_exists('event_start_datetime', $event_infos) ? $event_infos['event_start_datetime'] : (is_array($event_infos) && array_key_exists('event_upcoming_datetime', $event_infos) ? $event_infos['event_upcoming_datetime'] : '');
     $date                    = $url_date ?: $upcoming_date;
+
+	// Block booking for a past/expired selected occurrence (e.g. opened from a calendar
+	// link pointing at a date that has already passed). Mirrors the calendar's expiry rule
+	// so the detail page and the calendar agree on what is expired.
+	$selected_date_expired = false;
+	if ( ! empty( $user_date ) ) {
+		$expire_on = function_exists( 'mep_get_option' )
+			? mep_get_option( 'mep_event_expire_on_datetimes', 'general_setting_sec', 'event_start_datetime' )
+			: 'event_start_datetime';
+		$reference_dt = $user_date;
+		if ( $expire_on === 'event_end_datetime' ) {
+			$end_ref = $event_type === 'no' ? get_post_meta( $event_id, 'event_end_datetime', true ) : '';
+			if ( empty( $end_ref ) ) {
+				$end_time = get_post_meta( $event_id, 'event_end_time', true );
+				$end_ref  = $end_time ? date( 'Y-m-d', strtotime( $user_date ) ) . ' ' . $end_time : $user_date;
+			}
+			$reference_dt = $end_ref ?: $user_date;
+		}
+		$reference_ts = strtotime( $reference_dt );
+		$now_ts       = strtotime( current_time( 'Y-m-d H:i:s' ) );
+		if ( $reference_ts && $now_ts && $reference_ts < $now_ts ) {
+			$selected_date_expired = true;
+		}
+	}
+
 	ob_start();
 	if ( $event_id > 0 ) {
 		$reg_status = MPWEM_Global_Function::get_post_info( $event_id, 'mep_reg_status', 'on' );
-		if ( $reg_status == 'on' ) {
+		if ( $reg_status == 'on' && $selected_date_expired ) {
+			MPWEM_Layout::msg( esc_html__( 'Sorry, this date has expired and is no longer available for booking.', 'mage-eventpress' ), 'mpwem_date_expired_msg' );
+		} elseif ( $reg_status == 'on' ) {
 			$full_location = MPWEM_Functions::get_location( $event_id );
 			 //$total_available = MPWEM_Functions::get_total_available_seat( $event_id, $date );
 			// $total_available = max( $total_available, 0 );


### PR DESCRIPTION


When clicking an event in the FullCalendar view, the calendar linked every date instance to the bare event permalink with no date information. As a result the event detail page always fell back to the next upcoming date, which caused two problems:

1. Clicking a specific occurrence (e.g. 6 Jun) opened the event with the wrong date pre-selected in the ticket "Select date" control.
2. Clicking a past/expired occurrence opened the event in a bookable state, because the detail page defaulted to the upcoming date and never knew an expired instance had been clicked.

Changes:

- inc/MPWEM_Calendar.php Add append_date_to_url() helper and use it in build_event_data() so each calendar event URL carries its own occurrence as ?date=<timestamp>. The single-event page (get_all_info) and the date selector (date_select.php) already read $_GET['date'] as a Unix timestamp, so the clicked date is now pre-selected. Matches the existing convention used by date_list.php links.

- templates/layout/registration_content.php Add a per-selected-date expiry gate. Previously the booking form rendered whenever the event had any upcoming date, so a past occurrence of a recurring event still showed tickets. Now the selected occurrence is checked against the configured expire mode (event_start_datetime / event_end_datetime, mirroring the calendar's own rule); expired dates show an "expired and no longer available" notice instead of the ticket form. This runs in the shared render path, so it applies on initial page load and on AJAX date changes (get_mpwem_ticket).

- assets/frontend/mpwem_style.css Give the expired-date notice its own class (mpwem_date_expired_msg) with proper margin/padding instead of inheriting the zero-margin _margin_zero_text_center styling, so the message is clearly spaced.