### PR TITLE
Fix recurring special dates missing from calendar (upcoming filter)

### DIFF
--- a/inc/MPWEM_Calendar.php
+++ b/inc/MPWEM_Calendar.php
@@ -745,12 +745,38 @@ if ( ! class_exists( 'MPWEM_Calendar_Ajax' ) ) {
 				$expire_key = function_exists( 'mep_get_option' ) ? mep_get_option( 'mep_event_expire_on_datetimes', 'general_setting_sec', 'event_start_datetime' ) : 'event_start_datetime';
 				$expire_key = $expire_key == 'event_end_datetime' ? 'event_end_datetime' : 'event_upcoming_datetime';
 				$compare    = $query_status === 'expired' ? '<' : '>';
-				$meta_query[] = array(
+				$datetime_filter = array(
 					'key'     => $expire_key,
 					'value'   => $now,
 					'compare' => $compare,
 					'type'    => 'DATETIME',
 				);
+
+				if ( $query_status === 'upcoming' ) {
+					// Recurring events (multi-date "yes" / repeated "everyday") can have future
+					// occurrences — including special dates — that the single stored
+					// event_upcoming_datetime does not capture and which can also be stale.
+					// Filtering recurring events by that one datetime here wrongly hides those
+					// future dates (e.g. a special date set beyond the main range) from the
+					// calendar. So only single events are pre-filtered by their one datetime;
+					// recurring events are always loaded and the per-instance loop below drops
+					// any past/expired occurrence (respecting hide_expired / show_expired_events).
+					$meta_query[] = array(
+						'relation' => 'OR',
+						array(
+							'relation' => 'AND',
+							array(
+								'relation' => 'OR',
+								array( 'key' => 'mep_enable_recurring', 'value' => 'no', 'compare' => '=' ),
+								array( 'key' => 'mep_enable_recurring', 'compare' => 'NOT EXISTS' ),
+							),
+							$datetime_filter,
+						),
+						array( 'key' => 'mep_enable_recurring', 'value' => array( 'yes', 'everyday' ), 'compare' => 'IN' ),
+					);
+				} else {
+					$meta_query[] = $datetime_filter;
+				}
 			}
 
 			if ( count( $meta_query ) > 1 ) {


### PR DESCRIPTION
Recurring "everyday" events support extra "special dates" (mep_special_date_info) that can fall outside the main repeating range. These were not appearing in the calendar whenever the calendar was set to hide expired events.

Root cause:
The calendar's "upcoming" query pre-filtered events in SQL using the single stored event_upcoming_datetime meta. For recurring events that value is lossy: it does not account for special dates (the event save handler never recomputes event_upcoming_datetime to include them) and it goes stale over time as occurrences pass. So when show_expired_events is "no" (the real upcoming filter stays active), the whole event was excluded by SQL before its future special date could ever be generated/rendered. With the default show_expired_events "yes" the status is internally promoted to "all" and the filter is skipped, which is why the problem only surfaced on hide-expired calendars.

Fix (inc/MPWEM_Calendar.php):
For the "upcoming" status, only single ("no") events are pre-filtered by their one datetime. Recurring events (multi-date "yes" / repeated "everyday") are always loaded, and the existing per-instance loop continues to drop each past/expired occurrence (respecting hide_expired / show_expired_events). This makes future occurrences — including special dates set beyond the main range — show reliably regardless of whether event_upcoming_datetime is fresh, so it also fixes already-saved events without needing them re-saved. The "expired" status path is unchanged, and single-event filtering is unchanged (verified a past single event stays hidden when show_expired_events is "no").