### PR TITLE
fix: respect early bird status before checking sale end date/time

### DIFF
--- a/inc/MPWEM_Calendar.php
+++ b/inc/MPWEM_Calendar.php
@@ -1591,6 +1591,11 @@ if ( ! class_exists( 'MPWEM_Calendar_Ajax' ) ) {
 				return false;
 			}
 
+			$early_bird_status = function_exists( 'get_post_meta' ) ? get_post_meta( $event_id, 'mep_enable_early_bird_status', true ) : 'off';
+			if ( $early_bird_status !== 'on' ) {
+				return true;
+			}
+
 			$mep_hide_expire_ticket = function_exists( 'mep_get_option' ) ? mep_get_option( 'mep_hide_expire_ticket', 'general_setting_sec', 'no' ) : 'no';
 			$early_date             = apply_filters( 'mpwem_early_date', true, $ticket, $event_id );
 

--- a/inc/mep_functions.php
+++ b/inc/mep_functions.php
@@ -5596,6 +5596,10 @@ function mep_change_date_status() {
     if ( ! function_exists( 'mpwem_early_date_filter' ) ) {
         add_filter('mpwem_early_date', 'mpwem_early_date_filter', 10, 3);
         function mpwem_early_date_filter($return, $ticket_type, $event_id) {
+            $early_bird_status = get_post_meta( $event_id, 'mep_enable_early_bird_status', true );
+            if ( $early_bird_status !== 'on' ) {
+                return $return;
+            }
             $sale_start_datetime = is_array($ticket_type) && array_key_exists( 'option_sale_start_date_t', $ticket_type ) && !empty($ticket_type['option_sale_start_date_t']) ? date('Y-m-d H:i', strtotime($ticket_type['option_sale_start_date_t'])) : '';
             if ($sale_start_datetime) {
                 $current_time = current_time('Y-m-d H:i');

--- a/templates/layout/ticket_type.php
+++ b/templates/layout/ticket_type.php
@@ -24,6 +24,7 @@
 		$count        = 0;
 		if ( is_array( $ticket_types ) && sizeof( $ticket_types ) > 0 ) { ?>
             <div class="mpwem_ticket_type">
+			
                 <div class="card-body">
 					<?php foreach ( $ticket_types as $ticket_type ) {
 						$option_ticket_enable = is_array($ticket_type) && array_key_exists( 'option_ticket_enable', $ticket_type ) ? $ticket_type['option_ticket_enable'] : 'yes';
@@ -72,8 +73,9 @@
 									$count ++;
                                     $early_msg='yes';
 									$early_date = apply_filters( 'mpwem_early_date', true, $ticket_type, $event_id );
+									$early_bird_status = get_post_meta( $event_id, 'mep_enable_early_bird_status', true );
 									$mep_hide_expire_ticket=mep_get_option( 'mep_hide_expire_ticket', 'general_setting_sec', 'no' );
-									if ( $early_date ) {
+									if ( $early_date && $early_bird_status === 'on' ) {
 										$sale_end_datetime = is_array($ticket_type) && array_key_exists( 'option_sale_end_date_t', $ticket_type ) && ! empty( $ticket_type['option_sale_end_date_t'] ) ? date( 'Y-m-d H:i', strtotime( $ticket_type['option_sale_end_date_t'] ) ) : '';
 										if ( $sale_end_datetime ) {
 											$current_time = current_time( 'Y-m-d H:i' );
@@ -82,8 +84,10 @@
                                             }
                                         }
                                     }
+
                                     if($early_msg == 'yes'){
 									?>
+									
                                     <div class="mep_ticket_item">
                                         <div class="ticket-data">
                                             <div class="ticket-info">
@@ -116,9 +120,11 @@
                                                 <input type="hidden" name='option_name[]' value='<?php echo esc_attr( $ticket_name ); ?>'/>
                                                 <input type="hidden" name='ticket_type[]' value='<?php echo esc_attr( $ticket_name ); ?>'/>
 												<?php do_action( 'mpwem_hidden_item_ticket', $ticket_name, $event_id ); ?>
+								
 												<?php
 													$early_date = apply_filters( 'mpwem_early_date', true, $ticket_type, $event_id );
-													if ( $early_date ) {
+													$early_bird_status = get_post_meta( $event_id, 'mep_enable_early_bird_status', true );
+													if ( $early_date && $early_bird_status === 'on' ) {
 														$sale_end_datetime = is_array($ticket_type) && array_key_exists( 'option_sale_end_date_t', $ticket_type ) && ! empty( $ticket_type['option_sale_end_date_t'] ) ? date( 'Y-m-d H:i', strtotime( $ticket_type['option_sale_end_date_t'] ) ) : '';
 														if ( $sale_end_datetime ) {
 															$current_time = current_time( 'Y-m-d H:i' );
@@ -183,12 +189,40 @@
                                                             }
 														}
 													} else {
-														$sale_start_datetime = is_array($ticket_type) && array_key_exists( 'option_sale_start_date_t', $ticket_type ) && ! empty( $ticket_type['option_sale_start_date_t'] ) ? date( 'Y-m-d H:i', strtotime( $ticket_type['option_sale_start_date_t'] ) ) : '';
-														?>
-                                                        <span class='early-bird-future-date-txt' style="font-size: 12px;"><?php _e( 'Available On: ', 'mage-eventpress' );
-																echo get_mep_datetime( $sale_start_datetime, 'date-time-text' ); ?></span>
-                                                        <input type="hidden" name="option_qty[]" value="0" data-price="<?php echo esc_attr( $ticket_price ); ?>"/>
-														<?php
+														$early_bird_status = get_post_meta( $event_id, 'mep_enable_early_bird_status', true );
+														if ( $early_bird_status === 'on' ) {
+															$sale_start_datetime = is_array($ticket_type) && array_key_exists( 'option_sale_start_date_t', $ticket_type ) && ! empty( $ticket_type['option_sale_start_date_t'] ) ? date( 'Y-m-d H:i', strtotime( $ticket_type['option_sale_start_date_t'] ) ) : '';
+															?>
+                                                            <span class='early-bird-future-date-txt' style="font-size: 12px;"><?php _e( 'Available On: ', 'mage-eventpress' );
+																	echo get_mep_datetime( $sale_start_datetime, 'date-time-text' ); ?></span>
+                                                            <input type="hidden" name="option_qty[]" value="0" data-price="<?php echo esc_attr( $ticket_price ); ?>"/>
+															<?php
+														} else {
+                                                            $in_cart=0;
+                                                            $product_id = get_post_meta( $event_id, 'link_wc_product' );
+                                                            if ( isset( WC()->cart ) && ! empty( WC()->cart->get_cart() ) && ! empty( $date ) ) {
+                                                                foreach ( WC()->cart->get_cart() as $cart_item ) {
+                                                                    $cart_event_id = isset( $cart_item['event_id'] ) ? $cart_item['event_id'] : 0;
+                                                                    $cart_event_date = isset( $cart_item['event_cart_date'] ) ? $cart_item['event_cart_date'] : '';
+                                                                    $event_ticket_info = isset( $cart_item['event_ticket_info'] ) ? $cart_item['event_ticket_info'] : '';
+                                                                    $mep_check_date = isset($user_date) && !empty($user_date) ? $user_date : (isset($a_date) && !empty($a_date) ? $a_date : $date);
+                                                                    if ( $cart_event_id == $event_id && ! empty( $cart_event_date ) && $mep_check_date == $cart_event_date ) {
+                                                                        if(sizeof($event_ticket_info)>0){
+                                                                            foreach ($event_ticket_info as $key => $value) {
+                                                                                if($value['ticket_name']==$ticket_name){
+                                                                                    $in_cart=1;
+                                                                                }
+                                                                            }
+                                                                        }
+                                                                    }
+                                                                }
+                                                            }
+                                                            if($in_cart>0){
+                                                                _e( 'Already in Cart! ', 'mage-eventpress' );
+                                                            }else {
+                                                                MPWEM_Custom_Layout::qty_input($input_data);
+                                                            }
+														}
 													}
 												?>
                                             </div>

--- a/templates/layout/ticket_type_kera.php
+++ b/templates/layout/ticket_type_kera.php
@@ -154,7 +154,8 @@
 																		<?php
 																			if ( $exit_avail < 1 ) {
 																				$early_date = apply_filters( 'mpwem_early_date', true, $ticket_type, $event_id );
-																				if ( $early_date ) {
+																				$early_bird_status = get_post_meta( $event_id, 'mep_enable_early_bird_status', true );
+																				if ( $early_date && $early_bird_status === 'on' ) {
 																					$sale_end_datetime = is_array($ticket_type) && array_key_exists( 'option_sale_end_date_t', $ticket_type ) && ! empty( $ticket_type['option_sale_end_date_t'] ) ? date( 'Y-m-d H:i', strtotime( $ticket_type['option_sale_end_date_t'] ) ) : '';
 																					if ( $sale_end_datetime ) {
 																						$current_time = current_time( 'Y-m-d H:i' );
@@ -171,12 +172,17 @@
 																						MPWEM_Custom_Layout::qty_input( $input_data );
 																					}
 																				} else {
-																					$sale_start_datetime = is_array($ticket_type) && array_key_exists( 'option_sale_start_date_t', $ticket_type ) && ! empty( $ticket_type['option_sale_start_date_t'] ) ? date( 'Y-m-d H:i', strtotime( $ticket_type['option_sale_start_date_t'] ) ) : '';
-																					?>
-                                                                                    <span class='early-bird-future-date-txt' style="font-size: 12px;"><?php _e( 'Available On: ', 'mage-eventpress' );
-																							echo get_mep_datetime( $sale_start_datetime, 'date-time-text' ); ?></span>
-                                                                                    <input type="hidden" name="option_qty[]" value="0" data-price="<?php echo esc_attr( $ticket_price ); ?>"/>
-																					<?php
+																					$early_bird_status = get_post_meta( $event_id, 'mep_enable_early_bird_status', true );
+																					if ( $early_bird_status === 'on' ) {
+																						$sale_start_datetime = is_array($ticket_type) && array_key_exists( 'option_sale_start_date_t', $ticket_type ) && ! empty( $ticket_type['option_sale_start_date_t'] ) ? date( 'Y-m-d H:i', strtotime( $ticket_type['option_sale_start_date_t'] ) ) : '';
+																						?>
+                                                                                        <span class='early-bird-future-date-txt' style="font-size: 12px;"><?php _e( 'Available On: ', 'mage-eventpress' );
+																								echo get_mep_datetime( $sale_start_datetime, 'date-time-text' ); ?></span>
+                                                                                        <input type="hidden" name="option_qty[]" value="0" data-price="<?php echo esc_attr( $ticket_price ); ?>"/>
+																						<?php
+																					} else {
+																						MPWEM_Custom_Layout::qty_input( $input_data );
+																					}
 																				}
 																			} else {
 																				?> <input type="hidden" name="option_qty[]" value="0"  data-price="<?php echo esc_attr( $ticket_price ); ?>"/><?php


### PR DESCRIPTION
Problem:
- Ticket types were hidden from frontend when sale end date passed, even when early bird feature was disabled
- Sale end date/time logic was running unconditionally regardless of early bird enable/disable status

Root Cause:
- The mpwem_early_date filter and frontend templates did not check mep_enable_early_bird_status meta before applying sale date logic

Solution:
- Added early bird status check (mep_enable_early_bird_status) before sale end date/time validation in all relevant files

Files Modified:
- inc/mep_functions.php: Added early bird status check in mpwem_early_date_filter function
- templates/layout/ticket_type.php: Added early bird status check in both Layer 1 (ticket row visibility) and Layer 2 (qty input state)
- templates/layout/ticket_type_kera.php: Added early bird status check in sale date validation logic
- inc/MPWEM_Calendar.php: Added early bird status check in should_include_ticket_in_calendar method

Behavior:
- When early bird DISABLED: Sale dates ignored, tickets always shown
- When early bird ENABLED: Sale dates checked, tickets hidden/disabled accordingly