### PR TITLE
fix: format cart date through get_mep_datetime for non-recurring events

### DIFF
--- a/inc/MPWEM_Woocommerce.php
+++ b/inc/MPWEM_Woocommerce.php
@@ -279,7 +279,7 @@
 						}
 					} else {
 						if ( ! empty( $cart_date ) ) {
-							$item->add_meta_data( $date_text, $cart_date );
+							$item->add_meta_data( $date_text, get_mep_datetime( $cart_date, apply_filters( 'mep_cart_date_format', 'date-time-text' ), $event_id ) );
 						}
 					}
 					if ( is_array( $ticket_type_arr ) && sizeof( $ticket_type_arr ) > 0 ) {


### PR DESCRIPTION
- Line 282 was passing raw date value to order meta
- Now uses get_mep_datetime() with date-time-text format
- Consistent with recurring event date formatting on lines 261, 274