### PR TITLE
feat: add early bird sale period column to ticket type summary list

### DIFF
--- a/assets/admin/mpwem_event_edit.css
+++ b/assets/admin/mpwem_event_edit.css
@@ -2296,6 +2296,10 @@ div.mep_reg_status_show_msg_txt_sec textarea.formControl{
 	grid-template-columns: minmax(0, 1fr) minmax(88px, 0.42fr) minmax(68px, 0.3fr);
 	column-gap: 16px;
 }
+#mpwem_ticket_summary.is-earlybird .mpwem-ticket-summary__header,
+#mpwem_ticket_summary.is-earlybird .mpwem-ticket-summary__item {
+	grid-template-columns: minmax(0, 1fr) minmax(88px, 0.42fr) minmax(68px, 0.3fr) minmax(120px, 0.5fr);
+}
 .mpwem-ticket-summary__header,
 .mpwem-ticket-summary__item {
 	display: grid;
@@ -2449,6 +2453,19 @@ div.mep_reg_status_show_msg_txt_sec textarea.formControl{
 	font-weight: 400;
 }
 #mpwem_ticket_summary .mpwem-ticket-summary__capacity {
+	font-size: 14px;
+	line-height: 1.2;
+	font-weight: 400;
+	color: #10233f;
+}
+#mpwem_ticket_summary .mpwem-ticket-summary__header-earlybird {
+	text-align: right;
+}
+#mpwem_ticket_summary .mpwem-ticket-summary__meta--earlybird {
+	justify-self: end;
+	text-align: right;
+}
+#mpwem_ticket_summary .mpwem-ticket-summary__earlybird {
 	font-size: 14px;
 	line-height: 1.2;
 	font-weight: 400;

--- a/assets/admin/mpwem_event_edit.js
+++ b/assets/admin/mpwem_event_edit.js
@@ -763,6 +763,33 @@
         return value || 'No short description yet.';
     }
 
+    function isEarlyBirdEnabled($root) {
+        const context = getTicketModalContext($root);
+        return context.$modalMount.find('input[name="mep_enable_early_bird_status"]').first().is(':checked');
+    }
+
+    function ticketRowEarlyBirdDates($row) {
+        const startDate = ($row.find('[name="option_sale_start_date[]"]').first().val() || '').toString().trim();
+        const startTime = ($row.find('[name="option_sale_start_time[]"]').first().val() || '').toString().trim();
+        const endDate = ($row.find('[name="option_sale_end_date[]"]').first().val() || '').toString().trim();
+        const endTime = ($row.find('[name="option_sale_end_time[]"]').first().val() || '').toString().trim();
+
+        const startCombined = (startDate + ' ' + startTime).trim();
+        const endCombined = (endDate + ' ' + endTime).trim();
+
+        return { start: startCombined, end: endCombined };
+    }
+
+    function formatEarlyBirdDate(dateStr) {
+        if (!dateStr) return '';
+        const d = new Date(dateStr.replace(/-/g, '/'));
+        if (isNaN(d.getTime())) return dateStr;
+        const month = String(d.getMonth() + 1).padStart(2, '0');
+        const day = String(d.getDate()).padStart(2, '0');
+        const year = d.getFullYear();
+        return month + '/' + day + '/' + year;
+    }
+
     /* Delegates to the shared highlightRow helper defined near the top of this module. */
     function highlightTicketRow($row) {
         highlightRow($row);
@@ -785,13 +812,20 @@
             return;
         }
 
-        context.$summaryList.append(
-            $('<div class="mpwem-ticket-summary__header"></div>')
-                .append($('<span class="mpwem-ticket-summary__header-ticket"></span>').text('Ticket Type'))
-                .append($('<span class="mpwem-ticket-summary__header-price"></span>').text('Price'))
-                .append($('<span class="mpwem-ticket-summary__header-capacity"></span>').text('Total Qty'))
-                /* Planned: Action column header (.mpwem-ticket-summary__header-action) */
-        );
+        const earlyBirdEnabled = isEarlyBirdEnabled($root);
+
+        getPanel($root, '#mpwem_ticket_pricing_settings').find('#mpwem_ticket_summary').toggleClass('is-earlybird', earlyBirdEnabled);
+
+        const $headerRow = $('<div class="mpwem-ticket-summary__header"></div>')
+            .append($('<span class="mpwem-ticket-summary__header-ticket"></span>').text('Ticket Type'))
+            .append($('<span class="mpwem-ticket-summary__header-price"></span>').text('Price'))
+            .append($('<span class="mpwem-ticket-summary__header-capacity"></span>').text('Total Qty'));
+
+        if (earlyBirdEnabled) {
+            $headerRow.append($('<span class="mpwem-ticket-summary__header-earlybird"></span>').text('Sale Period'));
+        }
+
+        context.$summaryList.append($headerRow);
 
         if (!$rows.length) {
             context.$summaryList.append(
@@ -812,28 +846,47 @@
             const capacity = ticketSummaryQty($root, $row);
             const isDisabled = $row.hasClass('disable_row');
 
-            context.$summaryList.append(
-                $('<article class="mpwem-ticket-summary__item"></article>')
-                    .attr('data-ticket-row-index', index)
-                    .toggleClass('is-disabled', isDisabled)
-                    .append(
-                        $('<div class="mpwem-ticket-summary__item-main"></div>')
-                            .append(
-                                $('<div class="mpwem-ticket-summary__item-head"></div>')
-                                    .append($('<h4></h4>').text(name))
-                                    /* Planned: status badge (.mpwem-ticket-summary__status) showing Hidden/Active */
-                            )
-                    )
-                    .append(
-                        $('<div class="mpwem-ticket-summary__meta"></div>')
-                            .append($('<span class="mpwem-ticket-summary__price"></span>').text(price))
-                    )
-                    .append(
-                        $('<div class="mpwem-ticket-summary__meta mpwem-ticket-summary__meta--capacity"></div>')
-                            .append($('<span class="mpwem-ticket-summary__capacity"></span>').text(capacity))
-                    )
-                    /* Planned: per-row Details action button (data-mpwem-ticket-modal-open="details") */
-            );
+            const $item = $('<article class="mpwem-ticket-summary__item"></article>')
+                .attr('data-ticket-row-index', index)
+                .toggleClass('is-disabled', isDisabled)
+                .append(
+                    $('<div class="mpwem-ticket-summary__item-main"></div>')
+                        .append(
+                            $('<div class="mpwem-ticket-summary__item-head"></div>')
+                                .append($('<h4></h4>').text(name))
+                        )
+                )
+                .append(
+                    $('<div class="mpwem-ticket-summary__meta"></div>')
+                        .append($('<span class="mpwem-ticket-summary__price"></span>').text(price))
+                )
+                .append(
+                    $('<div class="mpwem-ticket-summary__meta mpwem-ticket-summary__meta--capacity"></div>')
+                        .append($('<span class="mpwem-ticket-summary__capacity"></span>').text(capacity))
+                );
+
+            if (earlyBirdEnabled) {
+                const dates = ticketRowEarlyBirdDates($row);
+                const startStr = formatEarlyBirdDate(dates.start);
+                const endStr = formatEarlyBirdDate(dates.end);
+                let periodText = '';
+                if (startStr && endStr) {
+                    periodText = startStr + ' - ' + endStr;
+                } else if (startStr) {
+                    periodText = 'From ' + startStr;
+                } else if (endStr) {
+                    periodText = 'Until ' + endStr;
+                } else {
+                    periodText = 'Not set';
+                }
+
+                $item.append(
+                    $('<div class="mpwem-ticket-summary__meta mpwem-ticket-summary__meta--earlybird"></div>')
+                        .append($('<span class="mpwem-ticket-summary__earlybird"></span>').text(periodText))
+                );
+            }
+
+            context.$summaryList.append($item);
         });
     }
 
@@ -1137,6 +1190,7 @@
 
         $root.on('change.mpwemTicketModal', '#mpwem_ticket_modal_mount input[name="mep_enable_early_bird_status"], #mpwem_ticket_modal_mount input[name="enable_global_qty"], #mpwem_ticket_modal_mount input[name="mep_show_advanced_column"], #mpwem_ticket_modal_mount select[name="mep_gq_type"], input[name="mpwem_show_mm"], select[name="mep_mm_min_max_type"]', function() {
             syncTicketAdvancedColumns($root);
+            renderTicketSummary($root);
         });
 
         $root.on('click.mpwemTicketModal', '[data-mpwem-open-particular-date-modal]', function(e) {


### PR DESCRIPTION
When the early bird (Sale Period) toggle is enabled on the event edit page, a new 'Sale Period' column now appears in the ticket type summary list (the non-editing overview section).

Changes:

JS (mpwem_event_edit.js):
- Added isEarlyBirdEnabled() helper to check if the early bird toggle is active
- Added ticketRowEarlyBirdDates() to extract start/end date+time from ticket row form fields (option_sale_start_date, option_sale_start_time, option_sale_end_date, option_sale_end_time)
- Added formatEarlyBirdDate() to format dates as MM/DD/YYYY
- Modified renderTicketSummary() to conditionally append a 'Sale Period' header column and per-ticket early bird date range display
- Added 'is-earlybird' class toggle on the summary container for CSS
- Updated the early bird toggle change handler to re-render the summary when toggled

CSS (mpwem_event_edit.css):
- Added 4-column grid layout for #mpwem_ticket_summary.is-earlybird to accommodate the new Sale Period column
- Added styles for .mpwem-ticket-summary__header-earlybird, .mpwem-ticket-summary__meta--earlybird, and .mpwem-ticket-summary__earlybird to match existing design patterns