### PR TITLE
fix: move deposit settings into Advanced tab and respect enable/disable toggle

### DIFF
--- a/admin/MPWEM_Event_Edit_Page.php
+++ b/admin/MPWEM_Event_Edit_Page.php
@@ -1668,6 +1668,7 @@ if (! class_exists('MPWEM_Event_Edit_Page')) {
 															<div class="mpwem-panel-mount" id="mpwem_wizard_email_reminder_mount"></div>
 															<div class="mpwem-panel-mount" id="mpwem_wizard_pdf_custom_text_mount"></div>
 															<div class="mpwem-panel-mount" id="mpwem_wizard_seo_mount"></div>
+															<div class="mpwem-panel-mount" id="mpwem_wizard_deposit_mount"></div>
 															<div class="mpwem-panel-mount" id="mpwem_wizard_settings_mount">
 																<?php $this->render_event_setting_options($post_id); ?>
 															</div>

--- a/assets/admin/mpwem_event_edit.js
+++ b/assets/admin/mpwem_event_edit.js
@@ -466,6 +466,7 @@
         mountPanel($root, '#mpwem_email_text_settings', 'mpwem_wizard_email_mount');
         mountPanel($root, '#mp_event_rich_text', 'mpwem_wizard_seo_mount');
         mountPanel($root, '#mp_event_reg_form_menu', 'mpwem_wizard_attendee_form_mount');
+        mountPanel($root, '#mep_deposit_settings_tab', 'mpwem_wizard_deposit_mount');
         mountDangerZone($root);
 
         const $legacySettingsPanel = $root.find('.mp_tab_item[data-tab-item="#mpwem_event_settings"]').first();
@@ -2436,6 +2437,13 @@
                 title: 'SEO & Schema',
                 desc: 'Control rich result details used by search engines.',
                 icon: 'dashicons-chart-bar'
+            },
+            {
+                mount: '#mpwem_wizard_deposit_mount',
+                className: 'mpwem-display-section--deposit',
+                title: 'Deposit / Partial Payment',
+                desc: 'Override the global deposit setting for this specific event.',
+                icon: 'dashicons-money-alt'
             },
             {
                 mount: '#mpwem_wizard_settings_mount',


### PR DESCRIPTION


- Remove deposit as a separate wizard step in the modern editor
- Add deposit mount point (mpwem_wizard_deposit_mount) inside the Advanced tab panel
- Add mountPanel call to relocate deposit panel into Advanced tab
- Add deposit section to enhanceDisplayStep for collapsible section header
- Deposit settings now appear as a collapsible section inside Advanced tab (alongside Templates, FAQs, SEO, etc.) instead of a standalone wizard step
- When deposit is disabled globally, the section is automatically hidden because the mount point stays empty