### PR TITLE
fix(mpwem-popup-date-picker): restore jQuery UI datepicker on attende…

### DIFF
--- a/admin/settings/global/admin_setting_panel.php
+++ b/admin/settings/global/admin_setting_panel.php
@@ -868,6 +868,9 @@ tr.payment_tabs_html { display: none !important; }
 				}
 
 				$payment_settings = get_option( 'payment_setting_sec', array() );
+				if ( ! is_array( $payment_settings ) ) {
+					$payment_settings = array();
+				}
 				$payment_settings['mep_enable_wc_payment'] = isset( $_POST['mep_enable_wc_payment'] ) ? sanitize_text_field( $_POST['mep_enable_wc_payment'] ) : 'off';
 				$payment_settings['mep_paypal_enable'] = isset( $_POST['mep_paypal_enable'] ) ? sanitize_text_field( $_POST['mep_paypal_enable'] ) : 'off';
 				$payment_settings['mep_stripe_enable'] = isset( $_POST['mep_stripe_enable'] ) ? sanitize_text_field( $_POST['mep_stripe_enable'] ) : 'off';

--- a/inc/MPWEM_Layout.php
+++ b/inc/MPWEM_Layout.php
@@ -120,7 +120,7 @@
                         <div class="_dFlex">
                             <label>
                                 <input type="hidden" name="mpwem_date_time" value="" required/>
-                                <input id="mpwem_date_time" type="text" value="" class="formControl _min_250" placeholder="<?php echo esc_attr( $now ); ?>" readonly required/>
+                                <input id="mpwem_date_time" type="text" value="" class="new-date_type formControl _min_250" placeholder="<?php echo esc_attr( $now ); ?>" readonly required/>
                             </label>
 							<?php if ( $display_time != 'no' && is_array( $all_times ) && sizeof( $all_times ) > 0 ) { ?>
                                 <div class="mpwem_time_area">


### PR DESCRIPTION
…e statistic popup

Two related fixes in the event-list attendee statistic modal:

1. admin/settings/global/admin_setting_panel.php (line 871) Guard against a corrupted/non-array value in the payment_setting_sec option. When stored as a string, the subsequent array offset writes triggered: TypeError: Cannot access offset of type string on string on PHP 8.x. Now we coerce to array before assignment.

2. inc/MPWEM_Layout.php (line 123) The custom-date-type branch of MPWEM_Layout::load_date() emits a visible <input id="mpwem_date_time"> with class 'formControl _min_250' only. After the AJAX popup loads, mpwem_admin.js calls mpwem_load_date_picker(target) (defined in mpwem_global.js), which only initializes jQuery UI datepicker on inputs matching .date_type / .new-date_type / .new-particular-date_type / .new-date_type-new. Without one of those classes, no picker ever attached and clicks on the date input did nothing.

   Fix: add the existing 'new-date_type' class to the visible input. This initializer uses minDate: today (correct, since the popup surfaces upcoming event statistics) and on select writes Y-m-d into the sibling hidden input and triggers change, which the existing .on('change', '.mpwem_popup_attendee_statistic [name="mpwem_date_time"]', ...) handler in mpwem_admin.js picks up to reload the statistics body via AJAX.

No change to public markup structure (hidden/visible pair, ids, names all preserved) and no change to any other load_date() branch.