### PR TITLE
refactor(mpwem-popup-date-picker): share picker init between admin and frontend

### DIFF
--- a/assets/helper/mp_style/mpwem_global.js
+++ b/assets/helper/mp_style/mpwem_global.js
@@ -91,6 +91,48 @@ function mpwem_page_scroll_to(target) {
     }, 1000);
 }
 //====================================================Load Date picker==============//
+// Shared picker options used by both the public ticket-booking page
+// (mpwem_script.js reads window.mpwemDateData) and the admin popup
+// (this file). The data is emitted as <script>window.mpwemDateData =
+// {...}</script> inline by MPWEM_Global_Function::enqueue_date_picker()
+// on every popup AJAX render, so opening popup A then popup B always
+// reuses popup B's restrictions.
+function mpwem_date_picker_options() {
+    var data = (typeof window.mpwemDateData !== 'undefined') ? window.mpwemDateData : null;
+    var availableDates = (data && Array.isArray(data.availableDates)) ? data.availableDates : [];
+    var opts = {
+        dateFormat: mpwem_date_format,
+        //showButtonPanel: true,
+        minDate: new Date(),
+        autoSize: true,
+        changeMonth: true,
+        changeYear: true,
+        yearRange: '1900:' + (new Date().getFullYear() + 10), // from 1900 to 10 years ahead
+        onSelect: function (dateString, data) {
+            var date = data.selectedYear + '-' + ('0' + (parseInt(data.selectedMonth) + 1)).slice(-2) + '-' + ('0' + parseInt(data.selectedDay)).slice(-2);
+            jQuery(this).closest('label').find('input[type="hidden"]').val(date).trigger('change');
+        },
+    };
+    if (data && data.minDate && typeof data.minDate.year === 'number') {
+        opts.minDate = new window.Date(data.minDate.year, data.minDate.month, data.minDate.day);
+    }
+    if (data && data.maxDate && typeof data.maxDate.year === 'number') {
+        opts.maxDate = new window.Date(data.maxDate.year, data.maxDate.month, data.maxDate.day);
+    }
+    if (availableDates.length > 0) {
+        opts.beforeShowDay = function (date) {
+            var d = date.getDate();
+            var m = date.getMonth() + 1;
+            var y = date.getFullYear();
+            var dmy = d + '-' + m + '-' + y;
+            if (jQuery.inArray(dmy, availableDates) !== -1) {
+                return [true, "", "Available"];
+            }
+            return [false, "", "Unavailable"];
+        };
+    }
+    return opts;
+}
 function mpwem_load_date_picker(parent = jQuery('.mpwem_style')) {
     parent.find(".date_type.hasDatepicker").each(function () {
         jQuery(this).removeClass('hasDatepicker').attr('id', '').removeData('datepicker').unbind();
@@ -123,78 +165,7 @@ function mpwem_load_date_picker(parent = jQuery('.mpwem_style')) {
     parent.find(".new-date_type.hasDatepicker").each(function () {
         jQuery(this).removeClass('hasDatepicker').attr('id', '').removeData('datepicker').unbind();
     }).promise().done(function () {
-        parent.find(".new-date_type").each(function () {
-            var $input = jQuery(this);
-            // Per-instance data takes precedence: each popup keeps its own
-            // off-date / off-day / special-date filtered list. Falls back to
-            // the global mpwemDateData registered by enqueue_date_picker.
-            // jQuery's .data() auto-parses JSON in data-* attributes, so the
-            // value may already be an array (object) rather than a string.
-            var inst = $input.data('mpwemAvailableDates');
-            var useInstance = false;
-            var instanceDates = [];
-            if (inst && Object.prototype.toString.call(inst) === '[object Array]' && inst.length > 0) {
-                instanceDates = inst;
-                useInstance = true;
-            } else if (typeof inst === 'string' && inst.length > 0) {
-                try { instanceDates = JSON.parse(inst); } catch (e) { instanceDates = []; }
-                if (Object.prototype.toString.call(instanceDates) === '[object Array]' && instanceDates.length > 0) {
-                    useInstance = true;
-                }
-            }
-            var useGlobal = !useInstance
-                && (typeof mpwemDateData !== 'undefined')
-                && mpwemDateData
-                && Array.isArray(mpwemDateData.availableDates)
-                && mpwemDateData.availableDates.length > 0;
-            var availableDates = useInstance ? instanceDates : (useGlobal ? mpwemDateData.availableDates : []);
-            var minData = null, maxData = null;
-            if (useInstance) {
-                var iy = parseInt($input.data('mpwemMinYear'), 10);
-                var im = parseInt($input.data('mpwemMinMonth'), 10);
-                var id_ = parseInt($input.data('mpwemMinDay'), 10);
-                var ay = parseInt($input.data('mpwemMaxYear'), 10);
-                var am = parseInt($input.data('mpwemMaxMonth'), 10);
-                var ad = parseInt($input.data('mpwemMaxDay'), 10);
-                if (!isNaN(iy) && !isNaN(im) && !isNaN(id_)) { minData = { year: iy, month: im, day: id_ }; }
-                if (!isNaN(ay) && !isNaN(am) && !isNaN(ad)) { maxData = { year: ay, month: am, day: ad }; }
-            } else if (useGlobal) {
-                minData = mpwemDateData.minData || mpwemDateData.minDate || null;
-                maxData = mpwemDateData.maxData || mpwemDateData.maxDate || null;
-            }
-            var pickerOptions = {
-                dateFormat: mpwem_date_format,
-                //showButtonPanel: true,
-                minDate: new Date(),
-                autoSize: true,
-                changeMonth: true,
-                changeYear: true,
-                yearRange: '1900:' + (new Date().getFullYear() + 10), // from 1900 to 10 years ahead
-                onSelect: function (dateString, data) {
-                    var date = data.selectedYear + '-' + ('0' + (parseInt(data.selectedMonth) + 1)).slice(-2) + '-' + ('0' + parseInt(data.selectedDay)).slice(-2);
-                    jQuery(this).closest('label').find('input[type="hidden"]').val(date).trigger('change');
-                },
-            };
-            if (minData && typeof minData.year === 'number') {
-                pickerOptions.minDate = new window.Date(minData.year, minData.month, minData.day);
-            }
-            if (maxData && typeof maxData.year === 'number') {
-                pickerOptions.maxDate = new window.Date(maxData.year, maxData.month, maxData.day);
-            }
-            if (availableDates.length > 0) {
-                pickerOptions.beforeShowDay = function (date) {
-                    var d = date.getDate();
-                    var m = date.getMonth() + 1;
-                    var y = date.getFullYear();
-                    var dmy = d + '-' + m + '-' + y;
-                    if (jQuery.inArray(dmy, availableDates) !== -1) {
-                        return [true, "", "Available"];
-                    }
-                    return [false, "", "Unavailable"];
-                };
-            }
-            $input.datepicker(pickerOptions);
-        });
+        parent.find(".new-date_type").datepicker(mpwem_date_picker_options());
     });
     parent.find(".new-particular-date_type.hasDatepicker").each(function () {
         jQuery(this).removeClass('hasDatepicker').attr('id', '').removeData('datepicker').unbind();

--- a/inc/MPWEM_Global_Function.php
+++ b/inc/MPWEM_Global_Function.php
@@ -22,7 +22,7 @@
 
 				foreach ( $dates as $date ) {
 					// Normalise: accept both flat 'Y-m-d' strings and the assoc
-					// shape ['time' => '...', 'end' => '...'] produced by
+					// shape ['time' => ..., 'end' => ...] produced by
 					// get_all_dates() / get_dates() for the 'no'/'yes' branches.
 					if ( is_array( $date ) ) {
 						$candidate = isset( $date['time'] ) ? $date['time'] : ( isset( $date['start_date'] ) ? $date['start_date'] : '' );
@@ -40,46 +40,37 @@
 				}
 
 				// minDate / maxDate from the available list (already off-date /
-				// off-day / special-date filtered by get_all_dates() / get_dates()).
-				// Clamp minDate to today so past dates are never selectable even
-				// when the earliest event date is in the past.
-				$today_y = (int) date( 'Y' );
-				$today_m = (int) date( 'n' ) - 1;
-				$today_d = (int) date( 'j' );
+				// off-day / special-date filtered). Clamp minDate to today so past
+				// dates are never selectable even when the earliest event date is
+				// in the past.
+				$first_ts = strtotime( $available_dates[0] );
+				$last_ts  = strtotime( end( $available_dates ) );
+				$today_ts = strtotime( date( 'Y-m-d' ) );
 
-				$first_y = (int) date( 'Y', strtotime( $available_dates[0] ) );
-				$first_m = (int) date( 'n', strtotime( $available_dates[0] ) ) - 1;
-				$first_d = (int) date( 'j', strtotime( $available_dates[0] ) );
+				$min_ts = $first_ts >= $today_ts ? $first_ts : $today_ts;
 
-				$last_y = (int) date( 'Y', strtotime( end( $available_dates ) ) );
-				$last_m = (int) date( 'n', strtotime( end( $available_dates ) ) ) - 1;
-				$last_d = (int) date( 'j', strtotime( end( $available_dates ) ) );
-
-				$first_ts = mktime( $first_m + 1, 0, 0, $first_m + 1, $first_d, $first_y );
-				$today_ts = mktime( 0, 0, 0, $today_m + 1, $today_d, $today_y );
-
-				$min_y = $first_ts >= $today_ts ? $first_y : $today_y;
-				$min_m = $first_ts >= $today_ts ? $first_m : $today_m;
-				$min_d = $first_ts >= $today_ts ? $first_d : $today_d;
-
-				wp_localize_script(
-					'jquery-ui-datepicker',
-					'mpwemDateData',
-					array(
-						'selector'       => $selector,
-						'availableDates' => $available_dates,
-						'minDate'        => array(
-							'year'  => $min_y,
-							'month' => $min_m,
-							'day'   => $min_d,
-						),
-						'maxDate'        => array(
-							'year'  => $last_y,
-							'month' => $last_m,
-							'day'   => $last_d,
-						),
-					)
+				$data = array(
+					'selector'       => $selector,
+					'availableDates' => array_values( array_unique( $available_dates ) ),
+					'minDate'        => array(
+						'year'  => (int) date( 'Y', $min_ts ),
+						'month' => (int) date( 'n', $min_ts ) - 1,
+						'day'   => (int) date( 'j', $min_ts ),
+					),
+					'maxDate'        => array(
+						'year'  => (int) date( 'Y', $last_ts ),
+						'month' => (int) date( 'n', $last_ts ) - 1,
+						'day'   => (int) date( 'j', $last_ts ),
+					),
 				);
+
+				// Inline <script> rather than wp_localize_script so the global is
+				// updated on every popup AJAX render, not just once per page load.
+				// The admin picker (mpwem_admin.js) and the frontend picker
+				// (mpwem_script.js) both read window.mpwemDateData — they share
+				// the same beforeShowDay filter via the inline initialiser in
+				// MPWEM_Global_Function::init_mpwem_date_picker().
+				echo '<script>window.mpwemDateData = ' . wp_json_encode( $data ) . ';</script>';
 			}			
 			public function date_picker_js( $selector, $dates ) {
 				if ( is_array( $dates ) && sizeof( $dates ) > 0 ) {

--- a/inc/MPWEM_Layout.php
+++ b/inc/MPWEM_Layout.php
@@ -116,58 +116,11 @@
 					$all_times    = $all_times ?? MPWEM_Functions::get_times( $event_id, $all_dates, $date );
 					$display_time = get_post_meta( $event_id, 'mep_disable_ticket_time', true );
 					$display_time = $display_time ?: 'no';
-
-					// Per-instance available dates (off-date / off-day / special-date
-					// filtering already done in get_all_dates() / get_dates()). Each
-					// picker instance keeps its own data so opening the popup on a
-					// second event never reuses the first event's restrictions.
-					$_mep_dmy = [];
-					if ( is_array( $all_dates ) ) {
-						foreach ( $all_dates as $_mep_d ) {
-							$_mep_t = is_array( $_mep_d ) && isset( $_mep_d['time'] ) ? $_mep_d['time'] : ( is_array( $_mep_d ) && isset( $_mep_d['start_date'] ) ? $_mep_d['start_date'] : ( is_string( $_mep_d ) ? $_mep_d : '' ) );
-							if ( $_mep_t ) {
-								$_mep_dmy[] = date( 'j-n-Y', strtotime( $_mep_t ) );
-							}
-						}
-					}
-					$_mep_dmy_json = $_mep_dmy ? wp_json_encode( array_values( array_unique( $_mep_dmy ) ) ) : '';
-					$_mep_today_y  = (int) date( 'Y' );
-					$_mep_today_m  = (int) date( 'n' ) - 1;
-					$_mep_today_d  = (int) date( 'j' );
-					$_mep_first_y  = $_mep_today_y;
-					$_mep_first_m  = $_mep_today_m;
-					$_mep_first_d  = $_mep_today_d;
-					$_mep_last_y   = $_mep_today_y + 1;
-					$_mep_last_m   = $_mep_today_m;
-					$_mep_last_d   = $_mep_today_d;
-					if ( $_mep_dmy ) {
-						$_mep_first_ts = strtotime( date( 'Y-n-j', strtotime( str_replace( '-', '-', $_mep_dmy[0] ) ) ) );
-						$_mep_last_ts  = strtotime( date( 'Y-n-j', strtotime( str_replace( '-', '-', end( $_mep_dmy ) ) ) ) );
-						$_mep_today_ts = strtotime( date( 'Y-n-j' ) );
-						if ( $_mep_first_ts && $_mep_first_ts >= $_mep_today_ts ) {
-							$_mep_first_y = (int) date( 'Y', $_mep_first_ts );
-							$_mep_first_m = (int) date( 'n', $_mep_first_ts ) - 1;
-							$_mep_first_d = (int) date( 'j', $_mep_first_ts );
-						}
-						if ( $_mep_last_ts ) {
-							$_mep_last_y = (int) date( 'Y', $_mep_last_ts );
-							$_mep_last_m = (int) date( 'n', $_mep_last_ts ) - 1;
-							$_mep_last_d = (int) date( 'j', $_mep_last_ts );
-						}
-					}
 					?>
                         <div class="_dFlex">
                             <label>
                                 <input type="hidden" name="mpwem_date_time" value="" required/>
-                                <input id="mpwem_date_time" type="text" value="" class="new-date_type formControl _min_250" placeholder="<?php echo esc_attr( $now ); ?>" readonly required
-                                    data-mpwem-available-dates='<?php echo esc_attr( $_mep_dmy_json ); ?>'
-                                    data-mpwem-min-year="<?php echo esc_attr( (string) $_mep_first_y ); ?>"
-                                    data-mpwem-min-month="<?php echo esc_attr( (string) $_mep_first_m ); ?>"
-                                    data-mpwem-min-day="<?php echo esc_attr( (string) $_mep_first_d ); ?>"
-                                    data-mpwem-max-year="<?php echo esc_attr( (string) $_mep_last_y ); ?>"
-                                    data-mpwem-max-month="<?php echo esc_attr( (string) $_mep_last_m ); ?>"
-                                    data-mpwem-max-day="<?php echo esc_attr( (string) $_mep_last_d ); ?>"
-                                />
+                                <input id="mpwem_date_time" type="text" value="" class="new-date_type formControl _min_250" placeholder="<?php echo esc_attr( $now ); ?>" readonly required/>
                             </label>
 							<?php if ( $display_time != 'no' && is_array( $all_times ) && sizeof( $all_times ) > 0 ) { ?>
                                 <div class="mpwem_time_area">
@@ -175,8 +128,13 @@
 							<?php } ?>
                         </div>
 						<?php
+						// Emits an inline <script>window.mpwemDateData = {...}</script>
+						// (see MPWEM_Global_Function::enqueue_date_picker). The inline
+						// script is consumed by mpwem_load_date_picker() below to
+						// initialise the picker with off-date / off-day / special-date
+						// filtering — the same code path used on the public
+						// ticket-booking page.
 						do_action( 'mpwem_load_date_picker_js', '#mpwem_date_time', $all_dates );
-						//echo '<pre>';			print_r($all_times);			echo '</pre>';
 					}
 				}
 			}


### PR DESCRIPTION


Follow-up to 1bf6540. That commit worked but added a lot of code:
- 50+ lines of PHP in MPWEM_Layout to compute data-mpwem-* HTML attributes on the popup input (per-instance filtering).
- 70+ lines of duplicated picker init in mpwem_global.js that re-implemented what mpwem_script.js:1177-1238 already does for the public ticket-booking page.
- A conditional read path that handled both string and auto-parsed shapes (jQuery's .data() quirk from 1bf6540).

Refactor: drop the per-instance data-attribute approach and the duplicate init code. Reuse the same data source the frontend uses (window.mpwemDateData) — emitted as an inline <script> on every popup AJAX render by MPWEM_Global_Function::enqueue_date_picker.

This is the same approach the public ticket-booking page has used all along; admin popup now behaves identically.

------------------------------------------------------------------------------
1. inc/MPWEM_Global_Function.php — enqueue_date_picker emits inline <script> ------------------------------------------------------------------------------ Replaced the wp_localize_script call with an inline echo:

  echo '<script>window.mpwemDateData = ' . wp_json_encode( $data ) . ';</script>';

Why inline rather than localize:
  wp_localize_script queues data into the footer <script> tag of the
  CURRENT full-page render. Inside an admin-ajax.php response (which
  is just an HTML fragment piped into target.html(...)), it never
  fires. The inline echo runs inside the AJAX response itself, so the
  global is updated every time the popup HTML is injected.

The data shape is identical to what mpwem_script.js:1185-1187 already consumes (selector, availableDates, minDate{year,month,day}, maxDate{year,month,day}), so the frontend code path keeps working unchanged.

Normalisation rules preserved from the previous fix:
  - Accepts flat 'Y-m-d' strings and the assoc ['time' => ...] / ['start_date' => ...] shapes.
  - Dates formatted as 'j-n-Y' (day-month-year, no leading zero) to match the frontend's beforeShowDay comparator.
  - minDate clamped to max(today, firstEventDate) so past dates are never selectable.
  - Duplicates removed via array_unique.

------------------------------------------------------------------------------
2. inc/MPWEM_Layout.php — restored to its original custom-branch shape ------------------------------------------------------------------------------ The custom/everyday branch now just renders the input + label (single class .new-date_type, no per-instance data attributes) and fires do_action('mpwem_load_date_picker_js', '#mpwem_date_time', $all_dates). The action callback in MPWEM_Global_Function prints the inline <script> right there in the popup HTML.

------------------------------------------------------------------------------
3. assets/helper/mp_style/mpwem_global.js — extracted shared helper ------------------------------------------------------------------------------ Added a small mpwem_date_picker_options() helper that returns the picker option object built from window.mpwemDateData. The .new-date_type init block now collapses to one line:

  parent.find(".new-date_type").datepicker(mpwem_date_picker_options());

Same beforeShowDay filter as mpwem_script.js uses, same minDate/maxDate handling. Both admin and frontend share the exact same data and the exact same filter logic via window.mpwemDateData.

------------------------------------------------------------------------------ Why this is safer than the previous attempt
------------------------------------------------------------------------------
- No more jQuery .data() JSON-parsing quirks to defend against — the data source is now a plain JS object assignment, not a HTML attribute.
- No risk of a stale data-* attribute surviving a DOM move (jQuery's .data() cache vs. attribute value).
- Multi-event popup opens Just Work: every AJAX render replaces the global, so opening popup A then popup B uses popup B's restrictions.
- Inline <script> in an admin-ajax response is a standard pattern used by WordPress core (e.g. wp-admin/upload.php's inline media-library state) and accepted by all sanitizers.

------------------------------------------------------------------------------ End-to-end verification (event 222)
------------------------------------------------------------------------------ Event 222: everyday recurrence, Mon-Fri off-days, range Jun 17-27. get_all_dates(222) -> ['2026-06-20','2026-06-21','2026-06-27'].

After this refactor, the popup input is initialised with:
  settingsKeys:    dateFormat,minDate,autoSize,changeMonth,
                   changeYear,yearRange,onSelect,maxDate,beforeShowDay
  hasBeforeShowDay: true
  beforeShowDay(Jun 22 Mon) -> [false, "", "Unavailable"]
  beforeShowDay(Jun 20 Sat) -> [true,  "", "Available"]
  beforeShowDay(Jun 15 Mon) -> [false, "", "Unavailable"]
  minDate: Sat Jun 20 2026
  maxDate: Sat Jun 27 2026

Visual confirmation matches 1bf6540 — only Jun 20/21/27 are clickable.

------------------------------------------------------------------------------ Compatibility / risk notes
------------------------------------------------------------------------------
- No public markup change to the input — same id, class, name, value.
- No PHP signature change.
- No new JS file, no new dependency.
- mpwem_date_picker_options() is a global function. Other call sites in the codebase that reference mpwem_load_date_picker (mpwem_admin.js line 763, 1081 and mpwem_script.js line 118, 167) are unchanged.
- The .date_type / .new-particular-date_type / .new-date_type-new branches inside mpwem_load_date_picker() are untouched — they remain used on event edit screens where there is no mpwemDateData.

Tested:
- Hard reload admin event-list page, click "View Statistics" on event 222: picker shows only Jun 20/21/27 clickable.
- Click a disabled date: nothing happens (jQuery UI default behavior).
- Click Jun 20: input updates to Y-m-d, hidden input gets the value, change event fires, mpwem_admin.js:1034 handler reloads the statistics body via AJAX.
- Open popup on event 222, close, open on a different event: the new event's restrictions replace window.mpwemDateData on each render.