### PR TITLE
Fix WooCommerce popup, built-in payment methods, and ticket validation

### DIFF
--- a/admin/MPWEM_Event_Edit_Page.php
+++ b/admin/MPWEM_Event_Edit_Page.php
@@ -1975,8 +1975,10 @@ if (! class_exists('MPWEM_Event_Edit_Page')) {
 						$price    = isset($ticket_prices[$i]) ? trim((string) $ticket_prices[$i]) : '';
 						$capacity = isset($ticket_caps[$i]) ? trim((string) $ticket_caps[$i]) : '';
 
-						// Skip a completely empty row.
-						if ('' === $name && '' === $price && '' === $capacity) {
+						// Skip blank/template rows. A valid ticket always needs at least a
+						// name and a price, so any row missing both is a template placeholder.
+						// (The default capacity "0" must not prevent this skip.)
+						if ('' === $name && '' === $price) {
 							continue;
 						}
 

--- a/admin/settings/MPWEM_Ticket_Price_Settings.php
+++ b/admin/settings/MPWEM_Ticket_Price_Settings.php
@@ -286,7 +286,7 @@
 												</div>
 											</div>
 
-											<label class="mpwem-pm-toggle-row mep-woo-enable-label" style="display:<?php echo $wc_active ? 'flex' : 'none'; ?>;">
+											<label class="mpwem-pm-toggle-row mep-woo-enable-label" style="display:flex;">
 												<span class="mpwem-pm-toggle-row__text">
 													<span class="mpwem-pm-toggle-row__label"><?php esc_html_e( 'Enable WooCommerce Payment Gateway', 'mage-eventpress' ); ?></span>
 													<span class="mpwem-pm-toggle-row__sub"><?php esc_html_e( 'Process ticket checkout through WooCommerce.', 'mage-eventpress' ); ?></span>
@@ -298,7 +298,7 @@
 											</label>
 										</div><!-- /.mpwem-pm-card -->
 
-										<div class="mep-modal-wc-fields" style="display: <?php echo ($woo_enabled && $wc_active) ? 'block' : 'none'; ?>;">
+										<div class="mep-modal-wc-fields" style="display: <?php echo $woo_enabled ? 'block' : 'none'; ?>;">
 											<!-- Payment Methods accordion (expanded by default) -->
 											<div class="mpwem-pm-acc mpwem-pm-acc--methods is-open">
 												<button type="button" class="mpwem-pm-acc__bar">
@@ -308,7 +308,7 @@
 												<div class="mpwem-pm-acc__panel">
 													<p class="mpwem-pm-card__sub"><?php esc_html_e( 'Enable and configure the WooCommerce gateways customers can pay with.', 'mage-eventpress' ); ?></p>
 													<?php
-													if ( $wc_active && class_exists( 'MPWEM_WC_Payment_Manager' ) ) {
+													if ( class_exists( 'MPWEM_WC_Payment_Manager' ) ) {
 														MPWEM_WC_Payment_Manager::instance()->render();
 													}
 													?>
@@ -515,22 +515,37 @@
 							var paypalOn  = $statusRow.data('paypal') == 1;
 							var stripeOn  = $statusRow.data('stripe') == 1;
 
-							// Names of the WooCommerce gateways that are currently enabled.
-							var gwNames = [];
+							// Use the live checkbox state when the modal is open; fall back to
+							// saved data-attrs when the modal hasn't been opened yet.
+							var $wcToggle   = $('#mep_modal_enable_wc');
+							var wcSectionOn = $wcToggle.length ? $wcToggle.is(':checked') : (wooOption || !optionSet);
+
+							// Split enabled gateways: WC-registered vs built-in (BACS / COD).
+							var wcGwNames    = [];
+							var builtinNames = [];
 							$('.mep-gw-toggle-input:checked').each(function() {
-								var name = $(this).closest('.mep-gw-card').find('.mep-gw-title').first().text().trim();
-								if (name) {
-									gwNames.push(name);
+								var $card  = $(this).closest('.mep-gw-card');
+								var source = $card.data('gateway-source') || 'wc';
+								var name   = $card.find('.mep-gw-title').first().text().trim();
+								if (!name) { return; }
+								if (source === 'builtin') {
+									builtinNames.push(name);
+								} else {
+									wcGwNames.push(name);
 								}
 							});
 
-							// WooCommerce counts as an active method when it is active, has an
-							// enabled gateway, and the admin has not explicitly turned it off.
-							var wcOn = wcActive && gwNames.length > 0 && (wooOption || !optionSet);
-
 							var methods = [];
-							if (wcOn) {
-								methods.push('WooCommerce (' + gwNames.join(', ') + ')');
+							if (wcSectionOn) {
+								// WC-registered gateways only count when WooCommerce is active.
+								if (wcActive && wcGwNames.length > 0) {
+									methods.push('WooCommerce (' + wcGwNames.join(', ') + ')');
+								}
+								// Built-in gateways (Bank Transfer, Cash on Delivery) are always
+								// valid regardless of WooCommerce being active.
+								if (builtinNames.length > 0) {
+									methods = methods.concat(builtinNames);
+								}
 							}
 							if (paypalOn) { methods.push('PayPal'); }
 							if (stripeOn) { methods.push('Stripe'); }
@@ -544,9 +559,10 @@
 								$warnRow.css('display', 'flex');
 							}
 
-							// Auto-enable the modal toggle when WooCommerce has an enabled
-							// gateway and the admin has not explicitly configured it yet.
-							if (!optionSet && gwNames.length > 0) {
+							// Auto-enable the payment section toggle when a gateway is already
+							// enabled but the admin hasn't explicitly saved the setting yet.
+							var anyGwEnabled = wcGwNames.length > 0 || builtinNames.length > 0;
+							if (!optionSet && anyGwEnabled) {
 								var $toggle = $('#mep_modal_enable_wc');
 								if ($toggle.length && !$toggle.is(':checked')) {
 									$toggle.prop('checked', true).trigger('change');

--- a/assets/admin/mpwem_event_edit.js
+++ b/assets/admin/mpwem_event_edit.js
@@ -1207,7 +1207,7 @@
 
             persistTicketDraftRows($root);
             $button.prop('disabled', true).addClass('is-saving');
-            submitEventForm($root, '');
+            submitEventForm($root, '', { skipPaymentCheck: true, skipOtherSteps: true });
 
             window.setTimeout(function() {
                 if ($button.closest('body').length) {
@@ -1596,7 +1596,7 @@
 
             persistExtraServiceDraftRows($root);
             $button.prop('disabled', true).addClass('is-saving');
-            submitEventForm($root, '');
+            submitEventForm($root, '', { skipOtherSteps: true });
 
             window.setTimeout(function() {
                 if ($button.closest('body').length) {
@@ -2266,7 +2266,7 @@
 
             persistParticularDateDraftRows($root);
             $button.prop('disabled', true).addClass('is-saving');
-            submitEventForm($root, '');
+            submitEventForm($root, '', { skipOtherSteps: true });
 
             window.setTimeout(function() {
                 if ($button.closest('body').length) {
@@ -5158,6 +5158,7 @@
     function validateTicketsStep($root, options) {
         options = options || {};
         const focus = options.focus !== false;
+        const skipPaymentCheck = options.skipPaymentCheck === true;
 
         // Requirements only apply to the Ticket-Selling (paid) event mode.
         if (!isRegistrationEnabled($root)) {
@@ -5168,15 +5169,20 @@
         let onFix = null;
 
         // 1) At least one payment method must be configured.
-        const $paymentWarning = $('.mpwem-payment-warning');
-        if ($paymentWarning.length && $paymentWarning.is(':visible')) {
-            message = 'Please configure at least one payment method to sell tickets.';
-            onFix = function() {
-                try {
-                    $paymentWarning[0].scrollIntoView({ behavior: 'smooth', block: 'center' });
-                } catch (e) {}
-                flashAttention($paymentWarning.find('.mep-payment-settings-trigger').first());
-            };
+        //    Skipped when saving ticket types from the modal so the user can
+        //    build their ticket list first and configure payment later.
+        //    The check still runs on Next Step navigation and Publish/Update.
+        if (!skipPaymentCheck) {
+            const $paymentWarning = $('.mpwem-payment-warning');
+            if ($paymentWarning.length && $paymentWarning.is(':visible')) {
+                message = 'Please configure at least one payment method to sell tickets.';
+                onFix = function() {
+                    try {
+                        $paymentWarning[0].scrollIntoView({ behavior: 'smooth', block: 'center' });
+                    } catch (e) {}
+                    flashAttention($paymentWarning.find('.mep-payment-settings-trigger').first());
+                };
+            }
         }
 
         // 2) At least one ticket type is required.
@@ -5664,23 +5670,27 @@
         return false;
     }
 
-    function submitEventForm($root, action) {
+    function submitEventForm($root, action, options) {
+        options = options || {};
         const $form = $('#mpwem-event-edit-form');
         if (!$form.length) {
             return;
         }
 
         if ((action || '') !== 'trash') {
-            if (!validateBasicStep($root, { focus: true })) {
+            // When saving from a step-specific modal (ticket/extra-service/date),
+            // only validate that step's own rules. Skipping cross-step validation
+            // prevents date/display failures from switching the active tab.
+            if (!options.skipOtherSteps && !validateBasicStep($root, { focus: true })) {
                 return;
             }
-            if (!validateTicketsStep($root, { focus: true })) {
+            if (!validateTicketsStep($root, { focus: true, skipPaymentCheck: options.skipPaymentCheck })) {
                 return;
             }
-            if (!validateDateStep($root, { focus: true })) {
+            if (!options.skipOtherSteps && !validateDateStep($root, { focus: true })) {
                 return;
             }
-            if (!validateDisplayStep($root, { focus: true })) {
+            if (!options.skipOtherSteps && !validateDisplayStep($root, { focus: true })) {
                 return;
             }
         }

--- a/assets/admin/wc-payment-manager.js
+++ b/assets/admin/wc-payment-manager.js
@@ -55,17 +55,19 @@
 		// Quick enable/disable toggle in the card header
 		// -----------------------------------------------------------
 		$manager.on( 'change', '.mep-gw-toggle-input', function () {
-			var $input = $( this );
-			var $card = $input.closest( '.mep-gw-card' );
-			var gatewayId = $input.data( 'gateway-id' );
-			var enabled = $input.is( ':checked' ) ? 'yes' : 'no';
+			var $input     = $( this );
+			var $card      = $input.closest( '.mep-gw-card' );
+			var gatewayId  = $input.data( 'gateway-id' );
+			var enabled    = $input.is( ':checked' ) ? 'yes' : 'no';
+			var source     = $card.data( 'gateway-source' ) || 'wc';
+			var ajaxAction = source === 'builtin' ? 'mep_toggle_builtin_gateway' : 'mep_wc_toggle_gateway';
 
 			$input.prop( 'disabled', true );
 
 			ajax( {
-				action: 'mep_wc_toggle_gateway',
+				action:     ajaxAction,
 				gateway_id: gatewayId,
-				enabled: enabled,
+				enabled:    enabled,
 			} )
 				.done( function ( res ) {
 					if ( res && res.success ) {

--- a/inc/MPWEM_Woo_Installer.php
+++ b/inc/MPWEM_Woo_Installer.php
@@ -55,8 +55,8 @@ if ( ! class_exists( 'MPWEM_Woo_Installer' ) ) {
 		}
 
 		/**
-		 * Runs on admin_init. If the transient from activation exists
-		 * and WooCommerce IS active, redirect to event lists page.
+		 * Runs on admin_init. If the transient from activation exists,
+		 * redirect to event lists page regardless of WooCommerce status.
 		 */
 		public function handle_activation_redirect() {
 			if ( ! get_transient( 'mpwem_plugin_activated' ) ) {
@@ -69,45 +69,18 @@ if ( ! class_exists( 'MPWEM_Woo_Installer' ) ) {
 				return;
 			}
 
-			// WooCommerce is active → redirect immediately
-			if ( $this->is_woo_active() ) {
-				delete_transient( 'mpwem_plugin_activated' );
-				wp_safe_redirect( admin_url( 'edit.php?post_type=mep_events&page=mep_event_lists' ) );
-				exit;
-			}
-
-			// WooCommerce is NOT active → clear transient, popup will show via should_show_popup()
 			delete_transient( 'mpwem_plugin_activated' );
+			wp_safe_redirect( admin_url( 'edit.php?post_type=mep_events&page=mep_event_lists' ) );
+			exit;
 		}
 
 		/**
-		 * Should we show the popup on this page load?
-		 *
-		 * Shown when the current user can manage plugins and WooCommerce is not
-		 * active, so they are prompted to install/activate it. The per-user
-		 * dismissal (the × button) hides it; maybe_reset_dismissal() clears that
-		 * flag once WooCommerce is active again, so the prompt returns the next
-		 * time WooCommerce is deactivated rather than staying hidden forever.
+		 * WooCommerce is no longer required — popup is permanently disabled.
 		 *
 		 * @return bool
 		 */
 		private function should_show_popup() {
-			// Only users who could actually act on the prompt.
-			if ( ! current_user_can( 'activate_plugins' ) ) {
-				return false;
-			}
-
-			// WooCommerce already active → nothing to prompt.
-			if ( $this->is_woo_active() ) {
-				return false;
-			}
-
-			// User chose to hide it for now.
-			if ( get_user_meta( get_current_user_id(), 'mpwem_woo_installer_dismissed', true ) ) {
-				return false;
-			}
-
-			return true;
+			return false;
 		}
 
 		/**

--- a/includes/admin/class-wc-payment-manager.php
+++ b/includes/admin/class-wc-payment-manager.php
@@ -31,6 +31,7 @@ if ( ! class_exists( 'MPWEM_WC_Payment_Manager' ) ) :
 			add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_assets' ], 20 );
 			add_action( 'wp_ajax_mep_wc_save_gateway', [ $this, 'ajax_save_gateway' ] );
 			add_action( 'wp_ajax_mep_wc_toggle_gateway', [ $this, 'ajax_toggle_gateway' ] );
+			add_action( 'wp_ajax_mep_toggle_builtin_gateway', [ $this, 'ajax_toggle_builtin_gateway' ] );
 		}
 
 		// ---------------------------------------------------------------
@@ -220,58 +221,119 @@ if ( ! class_exists( 'MPWEM_WC_Payment_Manager' ) ) :
 		}
 
 		// ---------------------------------------------------------------
-		// Render — called from the WooCommerce tab
+		// Built-in gateway specs (always shown regardless of WooCommerce)
+		// ---------------------------------------------------------------
+
+		private function builtin_gateway_specs(): array {
+			return [
+				'bacs' => [
+					'title' => __( 'Bank Transfer', 'mage-eventpress' ),
+					'desc'  => __( 'Allow customers to pay via direct bank transfer.', 'mage-eventpress' ),
+				],
+				'cod'  => [
+					'title' => __( 'Cash on Delivery', 'mage-eventpress' ),
+					'desc'  => __( 'Allow customers to pay with cash upon delivery or at the event.', 'mage-eventpress' ),
+				],
+			];
+		}
+
+		// ---------------------------------------------------------------
+		// Render — called from the Payment Configuration modal
 		// ---------------------------------------------------------------
 
 		public function render(): void {
-			if ( ! class_exists( 'WooCommerce' ) ) {
-				return;
+			$wc_active     = class_exists( 'WooCommerce' );
+			$builtin_specs = $this->builtin_gateway_specs();
+			$stored        = get_option( 'mep_builtin_gateways', [] );
+
+			// When WooCommerce is active, get its registered gateway objects.
+			$wc_gateways = $wc_active ? $this->get_all_gateways() : [];
+
+			// Build a unified render list: WC gateways first, then inject any
+			// built-in spec that WooCommerce hasn't registered, so BACS and COD
+			// are always present even on a fresh WooCommerce install or when
+			// WooCommerce is not active at all.
+			$render_items = [];
+
+			foreach ( $wc_gateways as $id => $gw ) {
+				$render_items[ $id ] = [
+					'id'      => $id,
+					'title'   => $gw->get_method_title() ?: $gw->get_title(),
+					'desc'    => $gw->get_method_description() ?: $gw->get_description(),
+					'enabled' => $gw->enabled === 'yes',
+					'source'  => 'wc',
+					'gw_obj'  => $gw,
+				];
 			}
 
-			$gateways = $this->get_all_gateways();
-			if ( empty( $gateways ) ) {
-				echo '<p>' . esc_html__( 'No payment gateways are registered.', 'mage-eventpress' ) . '</p>';
+			foreach ( $builtin_specs as $id => $spec ) {
+				if ( isset( $render_items[ $id ] ) ) {
+					continue; // Already covered by WooCommerce.
+				}
+				// Prefer the WooCommerce option value (accurate after WC is activated
+				// mid-session), fall back to plugin's own storage.
+				$wc_opt  = get_option( 'woocommerce_' . $id . '_settings', [] );
+				$enabled = isset( $wc_opt['enabled'] ) ? $wc_opt['enabled'] === 'yes'
+						 : ( isset( $stored[ $id ] ) && $stored[ $id ] === 'yes' );
+
+				$render_items[ $id ] = [
+					'id'      => $id,
+					'title'   => $spec['title'],
+					'desc'    => $spec['desc'],
+					'enabled' => $enabled,
+					'source'  => 'builtin',
+					'gw_obj'  => null,
+				];
+			}
+
+			if ( empty( $render_items ) ) {
 				return;
 			}
 			?>
 			<div class="mep-wc-payment-manager">
 				<div class="mep-wc-pm-bar">
-					<h3 class="mep-wc-pm-heading"><?php esc_html_e( 'WooCommerce Payment Methods', 'mage-eventpress' ); ?></h3>
+					<h3 class="mep-wc-pm-heading"><?php esc_html_e( 'Payment Methods', 'mage-eventpress' ); ?></h3>
+					<?php if ( $wc_active ) : ?>
 					<a href="<?php echo esc_url( admin_url( 'admin.php?page=wc-settings&tab=checkout' ) ); ?>"
 					   class="button button-small mep-wc-pm-wc-link" target="_blank">
 						<?php esc_html_e( 'Open in WooCommerce', 'mage-eventpress' ); ?>
 						<span class="dashicons dashicons-external" style="font-size:14px;line-height:1.4;vertical-align:middle;"></span>
 					</a>
+					<?php endif; ?>
 				</div>
 
-				<?php foreach ( $gateways as $gateway ) :
-					$is_enabled = ( $gateway->enabled === 'yes' );
-					$title      = $gateway->get_method_title() ?: $gateway->get_title();
-					$desc       = $gateway->get_method_description() ?: $gateway->get_description();
+				<?php foreach ( $render_items as $item ) :
+					$is_enabled = $item['enabled'];
 				?>
-				<div class="mep-gw-card <?php echo $is_enabled ? 'is-enabled' : 'is-disabled'; ?>" data-gateway-id="<?php echo esc_attr( $gateway->id ); ?>">
+				<div class="mep-gw-card <?php echo $is_enabled ? 'is-enabled' : 'is-disabled'; ?>"
+				     data-gateway-id="<?php echo esc_attr( $item['id'] ); ?>"
+				     data-gateway-source="<?php echo esc_attr( $item['source'] ); ?>">
 					<div class="mep-gw-head">
 						<div class="mep-gw-head-main">
 							<label class="mep-gw-toggle" title="<?php esc_attr_e( 'Enable / disable', 'mage-eventpress' ); ?>">
-								<input type="checkbox" class="mep-gw-toggle-input" data-gateway-id="<?php echo esc_attr( $gateway->id ); ?>" <?php checked( $is_enabled ); ?>>
+								<input type="checkbox" class="mep-gw-toggle-input"
+								       data-gateway-id="<?php echo esc_attr( $item['id'] ); ?>"
+								       <?php checked( $is_enabled ); ?>>
 								<span class="mep-gw-toggle-slider"></span>
 							</label>
-							<span class="mep-gw-title"><?php echo esc_html( $title ); ?></span>
+							<span class="mep-gw-title"><?php echo esc_html( $item['title'] ); ?></span>
 							<span class="mep-gw-badge"><?php echo $is_enabled ? esc_html__( 'Enabled', 'mage-eventpress' ) : esc_html__( 'Disabled', 'mage-eventpress' ); ?></span>
 						</div>
+						<?php if ( $item['gw_obj'] ) : ?>
 						<button type="button" class="button mep-gw-configure-btn"><?php esc_html_e( 'Configure', 'mage-eventpress' ); ?></button>
+						<?php endif; ?>
 					</div>
 
-					<?php if ( $desc ) : ?>
-						<div class="mep-gw-desc"><?php echo wp_kses_post( wpautop( $desc ) ); ?></div>
+					<?php if ( $item['desc'] ) : ?>
+					<div class="mep-gw-desc"><?php echo wp_kses_post( wpautop( $item['desc'] ) ); ?></div>
 					<?php endif; ?>
 
+					<?php if ( $item['gw_obj'] ) : ?>
 					<div class="mep-gw-body" style="display:none;">
-						<form class="mep-gw-form" data-gateway-id="<?php echo esc_attr( $gateway->id ); ?>">
+						<form class="mep-gw-form" data-gateway-id="<?php echo esc_attr( $item['id'] ); ?>">
 							<table class="form-table mep-gw-form-table">
 								<?php
-								// WooCommerce's OWN field rendering for this gateway.
-								echo $gateway->generate_settings_html( $gateway->get_form_fields(), false ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+								echo $item['gw_obj']->generate_settings_html( $item['gw_obj']->get_form_fields(), false ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 								?>
 							</table>
 							<div class="mep-gw-form-footer">
@@ -280,12 +342,59 @@ if ( ! class_exists( 'MPWEM_WC_Payment_Manager' ) ) :
 							</div>
 						</form>
 					</div>
+					<?php endif; ?>
 				</div>
 				<?php endforeach; ?>
 
 				<?php $this->render_styles(); ?>
 			</div>
 			<?php
+		}
+
+		// ---------------------------------------------------------------
+		// AJAX: toggle a built-in gateway (works without WooCommerce)
+		// ---------------------------------------------------------------
+
+		public function ajax_toggle_builtin_gateway(): void {
+			check_ajax_referer( 'mep_wc_payment_manager', 'nonce' );
+			if ( ! current_user_can( 'manage_options' ) && ! current_user_can( 'manage_woocommerce' ) ) {
+				wp_send_json_error( __( 'Permission denied.', 'mage-eventpress' ), 403 );
+			}
+
+			$gateway_id = sanitize_key( $_POST['gateway_id'] ?? '' );
+			$enabled    = ( isset( $_POST['enabled'] ) && $_POST['enabled'] === 'yes' ) ? 'yes' : 'no';
+
+			if ( empty( $gateway_id ) ) {
+				wp_send_json_error( __( 'Invalid gateway.', 'mage-eventpress' ) );
+			}
+
+			// Persist in the plugin's own store so state survives without WooCommerce.
+			$stored = get_option( 'mep_builtin_gateways', [] );
+			if ( ! is_array( $stored ) ) {
+				$stored = [];
+			}
+			$stored[ $gateway_id ] = $enabled;
+			update_option( 'mep_builtin_gateways', $stored );
+
+			// When WooCommerce is active, mirror the change in WooCommerce settings
+			// so enabling from here is also reflected in WC → Settings → Payments.
+			if ( class_exists( 'WooCommerce' ) ) {
+				$option_key = 'woocommerce_' . $gateway_id . '_settings';
+				$opts       = get_option( $option_key, [] );
+				if ( ! is_array( $opts ) ) {
+					$opts = [];
+				}
+				$opts['enabled'] = $enabled;
+				if ( $enabled === 'yes' ) {
+					$opts['_should_load'] = 'yes';
+				}
+				update_option( $option_key, $opts );
+				if ( WC()->payment_gateways() ) {
+					WC()->payment_gateways()->init();
+				}
+			}
+
+			wp_send_json_success( [ 'enabled' => $enabled ] );
 		}
 
 		private function render_styles(): void {

--- a/woocommerce-event-press.php
+++ b/woocommerce-event-press.php
@@ -334,6 +334,13 @@
 if ( ! function_exists( 'mep_pro_modify_admin_menu_capabilities' ) ) {
 	add_action( 'admin_menu', 'mep_modify_admin_menu_capabilities', 999 );
 	function mep_modify_admin_menu_capabilities() {
+		// Only swap manage_options → manage_woocommerce when WooCommerce is active.
+		// Without WooCommerce, manage_woocommerce is an unregistered capability so
+		// no user would have it, which hides all plugin menus for everyone.
+		if ( ! class_exists( 'WooCommerce' ) ) {
+			return;
+		}
+
 		global $menu, $submenu;
 
 		if ( ! empty( $menu ) ) {


### PR DESCRIPTION
## Summary

- **Disable WooCommerce install popup after activation** — Plugin no longer requires WooCommerce; on activation it always redirects to the event list page and the installer popup is permanently suppressed
- **Built-in Bank Transfer & Cash on Delivery** — BACS and COD now always appear in the Payment Methods list even without WooCommerce active; enabling them here also syncs to WooCommerce settings when WC is active; the payment status banner updates in real-time without a page reload
- **Ticket modal saves stay on the Tickets step** — Saving from the ticket/extra-service/date modals no longer triggers cross-step validation (date, display) that was silently switching the user to the Date tab
- **Payment check deferred to Next Step / Publish** — The "configure a payment method" gate is skipped when saving from the ticket modal so users can build their ticket list before setting up payment; the check still runs on Next Step navigation and Publish/Update
- **Fix false `ticket_fields` error on Publish** — The hidden template row has `option_qty_t = "0"` by default which tricked PHP into treating it as a real-but-incomplete ticket; the skip guard now only requires name and price both be empty
- **Fix: all Events menus hidden without WooCommerce** — `mep_modify_admin_menu_capabilities()` was unconditionally replacing every `manage_options` submenu capability with `manage_woocommerce`. Without WooCommerce active, `manage_woocommerce` is an unregistered capability so no user possesses it, hiding Settings, Analytics, RSVP, Status and all other plugin-added menus (only the 4 built-in CPT entries remained visible). Fix guards the swap with `class_exists(WooCommerce)`.

## Test plan

- [ ] Fresh install with no WooCommerce → **all** Events submenu items are visible (Settings, Analytics, RSVP Responses, Status, etc.)
- [ ] Activate plugin with WooCommerce inactive → redirects to Events list, no WooCommerce popup
- [ ] Open Configure Payments → enable WooCommerce payment toggle → Bank Transfer and COD appear in the list
- [ ] Toggle COD on → banner shows "Payment Method Enabled: Cash on Delivery" immediately
- [ ] Add a ticket type in the modal and click Save Changes → stays on Tickets step, does not jump to Date tab
- [ ] Click Save Changes in ticket modal without configuring payment → no payment error; error only appears on Next Step / Publish
- [ ] Fill all required fields (ticket name, price, capacity, event dates) and click Publish → event publishes without false ticket_fields error
- [ ] Install & activate WooCommerce → Shop Manager role can still access all Events menus

🤖 Generated with [Claude Code](https://claude.ai/claude-code)