### PR TITLE
Payment gateway fixes + Step-2/4 wizard refinements

### DIFF
--- a/admin/MPWEM_Event_Edit_Page.php
+++ b/admin/MPWEM_Event_Edit_Page.php
@@ -1228,7 +1228,7 @@ if (! class_exists('MPWEM_Event_Edit_Page')) {
 			$can_trash    = $post_id && current_user_can('delete_post', $post_id);
 
 		?>
-			<div class="mpwem-event-wizard is-loading" data-event-id="<?php echo esc_attr($post_id); ?>">
+			<div class="mpwem-event-wizard is-loading" data-event-id="<?php echo esc_attr($post_id); ?>" data-is-published="<?php echo $is_published ? '1' : '0'; ?>" data-can-publish="<?php echo $can_publish ? '1' : '0'; ?>">
 				<div class="mpwem-event-wizard__skeleton" aria-hidden="true">
 					<div class="mpwem-skeleton-topbar">
 						<span class="mpwem-skeleton-line mpwem-skeleton-line--back"></span>
@@ -1551,20 +1551,6 @@ if (! class_exists('MPWEM_Event_Edit_Page')) {
 																<input type="hidden" name="mep_reg_status" id="mep_reg_status" value="<?php echo esc_attr($current_mode); ?>" />
 																
 																<div class="mpwem-event-type-toggle" id="mpwem_event_mode_toggle" style="margin-top: 10px; grid-template-columns: repeat(3, 1fr);">
-																	<div class="mpwem-event-type-option <?php echo ($current_mode === 'off') ? 'is-active' : ''; ?>" data-value="off">
-																		<span class="dashicons dashicons-list-view"></span>
-																		<div>
-																			<strong><?php esc_html_e('Listing-Only', 'mage-eventpress'); ?></strong>
-																			<small><?php esc_html_e('No Registration', 'mage-eventpress'); ?></small>
-																		</div>
-																	</div>
-																	<div class="mpwem-event-type-option <?php echo ($current_mode === 'rsvp') ? 'is-active' : ''; ?>" data-value="rsvp">
-																		<span class="dashicons dashicons-email-alt"></span>
-																		<div>
-																			<strong><?php esc_html_e('RSVP', 'mage-eventpress'); ?></strong>
-																			<small><?php esc_html_e('Free Registration', 'mage-eventpress'); ?></small>
-																		</div>
-																	</div>
 																	<div class="mpwem-event-type-option <?php echo ($current_mode === 'on') ? 'is-active' : ''; ?>" data-value="on">
 																		<span class="dashicons dashicons-tickets-alt"></span>
 																		<div>
@@ -1578,6 +1564,20 @@ if (! class_exists('MPWEM_Event_Edit_Page')) {
 																				}
 																				?>
 																			</small>
+																		</div>
+																	</div>
+																	<div class="mpwem-event-type-option <?php echo ($current_mode === 'rsvp') ? 'is-active' : ''; ?>" data-value="rsvp">
+																		<span class="dashicons dashicons-email-alt"></span>
+																		<div>
+																			<strong><?php esc_html_e('RSVP', 'mage-eventpress'); ?></strong>
+																			<small><?php esc_html_e('Free Registration', 'mage-eventpress'); ?></small>
+																		</div>
+																	</div>
+																	<div class="mpwem-event-type-option <?php echo ($current_mode === 'off') ? 'is-active' : ''; ?>" data-value="off">
+																		<span class="dashicons dashicons-list-view"></span>
+																		<div>
+																			<strong><?php esc_html_e('Listing-Only', 'mage-eventpress'); ?></strong>
+																			<small><?php esc_html_e('No Registration', 'mage-eventpress'); ?></small>
 																		</div>
 																	</div>
 																</div>
@@ -1897,6 +1897,32 @@ if (! class_exists('MPWEM_Event_Edit_Page')) {
 <?php
 		}
 
+		/**
+		 * Whether a FAQ/Timeline section has at least one item with BOTH a title
+		 * and a (non-empty) description. Parallel arrays of titles and contents are
+		 * compared by index; fully blank rows are ignored, but any row that has one
+		 * of the two without the other makes the set incomplete.
+		 *
+		 * @param array $titles   Item titles (raw).
+		 * @param array $contents Item descriptions / HTML bodies (raw).
+		 */
+		private function display_items_complete(array $titles, array $contents): bool
+		{
+			$started = 0;
+			foreach ($titles as $i => $title) {
+				$title   = trim((string) $title);
+				$content = isset($contents[$i]) ? trim(wp_strip_all_tags(str_replace('&nbsp;', ' ', (string) $contents[$i]))) : '';
+				if ('' === $title && '' === $content) {
+					continue;
+				}
+				$started++;
+				if ('' === $title || '' === $content) {
+					return false;
+				}
+			}
+			return $started > 0;
+		}
+
 		public function handle_save(): void
 		{
 			if (! $this->can_manage_events()) {
@@ -2099,16 +2125,20 @@ if (! class_exists('MPWEM_Event_Edit_Page')) {
 				}
 
 				// Advanced (Display) step — FAQ, Timeline and Related Events requirements.
+				// Each enabled section needs at least one item with BOTH a title and
+				// a description; fully blank rows are dropped on save and ignored here.
 				if ('' === $validation_error && isset($_POST['mep_faq_status']) && $_POST['mep_faq_status']) {
-					$faq_titles = isset($_POST['mep_faq_title']) && is_array($_POST['mep_faq_title']) ? array_map('trim', (array) wp_unslash($_POST['mep_faq_title'])) : [];
-					if (empty(array_filter($faq_titles, 'strlen'))) {
+					$faq_titles   = isset($_POST['mep_faq_title']) && is_array($_POST['mep_faq_title']) ? array_values((array) wp_unslash($_POST['mep_faq_title'])) : [];
+					$faq_contents = isset($_POST['mep_faq_content']) && is_array($_POST['mep_faq_content']) ? array_values((array) wp_unslash($_POST['mep_faq_content'])) : [];
+					if (! $this->display_items_complete($faq_titles, $faq_contents)) {
 						$validation_error = 'faq_items';
 					}
 				}
 
 				if ('' === $validation_error && isset($_POST['mep_timeline_status']) && $_POST['mep_timeline_status']) {
-					$tl_titles = isset($_POST['mep_day_title']) && is_array($_POST['mep_day_title']) ? array_map('trim', (array) wp_unslash($_POST['mep_day_title'])) : [];
-					if (empty(array_filter($tl_titles, 'strlen'))) {
+					$tl_titles   = isset($_POST['mep_day_title']) && is_array($_POST['mep_day_title']) ? array_values((array) wp_unslash($_POST['mep_day_title'])) : [];
+					$tl_contents = isset($_POST['mep_day_content']) && is_array($_POST['mep_day_content']) ? array_values((array) wp_unslash($_POST['mep_day_content'])) : [];
+					if (! $this->display_items_complete($tl_titles, $tl_contents)) {
 						$validation_error = 'timeline_items';
 					}
 				}

--- a/admin/settings/MPWEM_Ticket_Price_Settings.php
+++ b/admin/settings/MPWEM_Ticket_Price_Settings.php
@@ -34,7 +34,9 @@
 					$woo_enabled = isset($payment_opts['mep_enable_wc_payment']) && $payment_opts['mep_enable_wc_payment'] === 'on';
 					$paypal_enabled = isset($payment_opts['mep_paypal_enable']) && $payment_opts['mep_paypal_enable'] === 'on';
 					$stripe_enabled = isset($payment_opts['mep_stripe_enable']) && $payment_opts['mep_stripe_enable'] === 'on';
-					$show_payment_warning = !$woo_enabled && !$paypal_enabled && !$stripe_enabled;
+					$offline_enabled = isset($payment_opts['mep_offline_enable']) && $payment_opts['mep_offline_enable'] === 'on';
+					$offline_label = ! empty($payment_opts['mep_offline_label']) ? $payment_opts['mep_offline_label'] : __('Offline Payment', 'mage-eventpress');
+					$show_payment_warning = !$woo_enabled && !$paypal_enabled && !$stripe_enabled && !$offline_enabled;
 					
 					$wc_add_to_cart_redirect = isset($payment_opts['mep_wc_add_to_cart_redirect']) ? $payment_opts['mep_wc_add_to_cart_redirect'] : 'checkout';
 					$wc_after_order_redirect = isset($payment_opts['mep_wc_after_order_redirect']) ? $payment_opts['mep_wc_after_order_redirect'] : 'plugin_thankyou';
@@ -66,6 +68,8 @@
 							data-wc-active="<?php echo $wc_active ? '1' : '0'; ?>"
 							data-paypal="<?php echo $paypal_enabled ? '1' : '0'; ?>"
 							data-stripe="<?php echo $stripe_enabled ? '1' : '0'; ?>"
+							data-offline="<?php echo $offline_enabled ? '1' : '0'; ?>"
+							data-offline-label="<?php echo esc_attr( $offline_label ); ?>"
 							style="background: #e6f4ea; color: #0a7c2f; padding: 15px; border-left: 4px solid #34c759; border-radius: var(--mpwem-radius); display: <?php echo $show_payment_warning ? 'none' : 'flex'; ?>; justify-content: space-between; align-items: center; flex-wrap: wrap; gap: 15px;">
 							<div>
 								<strong style="display: block; font-size: 14px; margin-bottom: 5px;"><i class="fas fa-check-circle" style="margin-right: 5px;"></i><?php esc_html_e( 'Payment Method Enabled', 'mage-eventpress' ); ?></strong>
@@ -286,7 +290,7 @@
 												</div>
 											</div>
 
-											<label class="mpwem-pm-toggle-row mep-woo-enable-label" style="display:flex;">
+											<label class="mpwem-pm-toggle-row mep-woo-enable-label" style="display: <?php echo $wc_active ? 'flex' : 'none'; ?>;">
 												<span class="mpwem-pm-toggle-row__text">
 													<span class="mpwem-pm-toggle-row__label"><?php esc_html_e( 'Enable WooCommerce Payment Gateway', 'mage-eventpress' ); ?></span>
 													<span class="mpwem-pm-toggle-row__sub"><?php esc_html_e( 'Process ticket checkout through WooCommerce.', 'mage-eventpress' ); ?></span>
@@ -298,7 +302,7 @@
 											</label>
 										</div><!-- /.mpwem-pm-card -->
 
-										<div class="mep-modal-wc-fields" style="display: <?php echo $woo_enabled ? 'block' : 'none'; ?>;">
+										<div class="mep-modal-wc-fields" style="display: <?php echo ( $wc_active && $woo_enabled ) ? 'block' : 'none'; ?>;">
 											<!-- Payment Methods accordion (expanded by default) -->
 											<div class="mpwem-pm-acc mpwem-pm-acc--methods is-open">
 												<button type="button" class="mpwem-pm-acc__bar">
@@ -416,7 +420,11 @@
 														<strong class="mpwem-pm-gateway__name"><?php esc_html_e( 'Offline Payment', 'mage-eventpress' ); ?></strong>
 													</div>
 												</div>
-												<button type="button" id="mep-offline-configure-btn" class="button button-secondary"><?php esc_html_e( 'Configure', 'mage-eventpress' ); ?></button>
+												<?php if ( $is_pro ) : ?>
+													<button type="button" id="mep-offline-configure-btn" class="button button-secondary"><?php esc_html_e( 'Configure', 'mage-eventpress' ); ?></button>
+												<?php else : ?>
+													<span class="mpwem-pm-pro-badge" title="<?php esc_attr_e('Available in Pro version', 'mage-eventpress'); ?>">PRO</span>
+												<?php endif; ?>
 											</div>
 										</div>
 
@@ -514,6 +522,8 @@
 							var wcActive  = $statusRow.data('wc-active') == 1;
 							var paypalOn  = $statusRow.data('paypal') == 1;
 							var stripeOn  = $statusRow.data('stripe') == 1;
+							var offlineOn = $statusRow.data('offline') == 1;
+							var offlineLabel = $statusRow.data('offline-label') || 'Offline Payment';
 
 							// Use the live checkbox state when the modal is open; fall back to
 							// saved data-attrs when the modal hasn't been opened yet.
@@ -549,6 +559,7 @@
 							}
 							if (paypalOn) { methods.push('PayPal'); }
 							if (stripeOn) { methods.push('Stripe'); }
+							if (offlineOn) { methods.push(offlineLabel); }
 
 							if (methods.length > 0) {
 								$statusRow.find('.mpwem-payment-status__methods').text(methods.join(', '));
@@ -574,6 +585,12 @@
 
 						// Keep the status row in sync when a gateway is toggled inside the modal.
 						$(document).on('change', '.mep-gw-toggle-input', function() {
+							mepRefreshPaymentStatus();
+						});
+						// The gateway manager fires this after it reconciles a toggle with
+						// the gateway's real saved state (a programmatic checkbox change does
+						// not emit a native 'change' event).
+						$(document).on('mep:gateways-refresh', function() {
 							mepRefreshPaymentStatus();
 						});
 
@@ -628,6 +645,16 @@
 											var wooOn = $('#mep_modal_enable_wc').is(':checked') ? 1 : 0;
 											$statusRow.data('option-set', 1).attr('data-option-set', '1');
 											$statusRow.data('woo-enabled', wooOn).attr('data-woo-enabled', String(wooOn));
+											// WooCommerce and custom gateways are mutually exclusive —
+											// turning WooCommerce on clears the custom gateway flags
+											// and unchecks the custom Configure-modal toggles so they
+											// don't flip everything back on the next save.
+											if (wooOn) {
+												$.each(['paypal', 'stripe', 'offline'], function(i, gw) {
+													$statusRow.data(gw, 0).attr('data-' + gw, '0');
+													$('input[data-field="mep_' + gw + '_enable"]').prop('checked', false);
+												});
+											}
 										}
 										mepRefreshPaymentStatus();
 

--- a/admin/settings/global/admin_setting_panel.php
+++ b/admin/settings/global/admin_setting_panel.php
@@ -527,6 +527,26 @@
 									$badge.text(isEnabled ? mepGateway.enabled : mepGateway.disabled);
 									$badge.toggleClass('active', isEnabled);
 								}
+
+								// Reflect the change on the Event Edit → Payment status banner
+								// (when configured from inside the event modal) and enforce
+								// mutual exclusivity: enabling a custom gateway turns the
+								// WooCommerce payment toggle off.
+								var $statusRow = $('.mpwem-payment-status');
+								if ($statusRow.length) {
+									var gwOn = fields['mep_' + gateway + '_enable'] === 'on';
+									$statusRow.attr('data-' + gateway, gwOn ? '1' : '0').data(gateway, gwOn ? 1 : 0);
+									if (gateway === 'offline' && fields['mep_offline_label']) {
+										$statusRow.attr('data-offline-label', fields['mep_offline_label']).data('offline-label', fields['mep_offline_label']);
+									}
+									if (gwOn) {
+										$('#mep_modal_enable_wc').prop('checked', false);
+										$('.mep-modal-wc-fields').stop(true, true).slideUp(200);
+										$statusRow.attr('data-woo-enabled', '0').data('woo-enabled', 0);
+										$statusRow.attr('data-option-set', '1').data('option-set', 1);
+									}
+									$(document).trigger('mep:gateways-refresh');
+								}
 							} else {
 								$msg.css({'color':'#842029','background':'#f8d7da','border':'1px solid #f5c2c7'}).text(res.data).fadeIn(200);
 								setTimeout(function() { $msg.fadeOut(400); }, 1000);
@@ -580,6 +600,14 @@
 				} else {
 					$existing[ $key ] = sanitize_text_field( $val );
 				}
+			}
+
+			// Custom payment is mutually exclusive with the WooCommerce checkout.
+			// Switching a custom gateway on turns the WooCommerce payment master
+			// toggle off, so the banner and checkout never advertise both at once.
+			$enable_key = 'mep_' . $gateway . '_enable';
+			if ( isset( $existing[ $enable_key ] ) && 'on' === $existing[ $enable_key ] ) {
+				$existing['mep_enable_wc_payment'] = 'off';
 			}
 
 			update_option( 'payment_setting_sec', $existing );
@@ -1062,6 +1090,15 @@ tr.payment_tabs_html { display: none !important; }
 				// Configure modal (its own enable toggle). The Custom Payment tab no longer
 				// has those checkboxes, so we must NOT touch those keys here or every save
 				// would disable the gateways.
+				//
+				// Exception: WooCommerce and the custom (native checkout) gateways are
+				// mutually exclusive. When WooCommerce payment is turned ON, switch the
+				// custom gateways OFF so the banner/checkout never advertise both.
+				if ( 'on' === $payment_settings['mep_enable_wc_payment'] ) {
+					$payment_settings['mep_paypal_enable']  = 'off';
+					$payment_settings['mep_stripe_enable']  = 'off';
+					$payment_settings['mep_offline_enable'] = 'off';
+				}
 
 				$payment_settings['mep_wc_add_to_cart_redirect'] = isset( $_POST['mep_wc_add_to_cart_redirect'] ) ? sanitize_text_field( $_POST['mep_wc_add_to_cart_redirect'] ) : 'checkout';
 				$payment_settings['mep_wc_after_order_redirect'] = isset( $_POST['mep_wc_after_order_redirect'] ) ? sanitize_text_field( $_POST['mep_wc_after_order_redirect'] ) : 'plugin_thankyou';

--- a/assets/admin/mpwem_event_edit.js
+++ b/assets/admin/mpwem_event_edit.js
@@ -4679,6 +4679,19 @@
         return !blockOnError;
     }
 
+    // Final-step save button: a not-yet-published event publishes on save, an
+    // already-published event updates in place. The button label mirrors the
+    // action it performs.
+    function isPublishedEvent($root) {
+        return String($root.data('is-published')) === '1';
+    }
+    function finalSaveAction($root) {
+        return isPublishedEvent($root) ? '' : 'publish';
+    }
+    function finalSaveLabel($root) {
+        return isPublishedEvent($root) ? 'Save & Update Event' : 'Save & Publish Event';
+    }
+
     function setActiveStep($root, stepKey, options) {
         if (stepKey !== 'tickets') {
             closeTicketModal($root);
@@ -4752,7 +4765,7 @@
         const current = $visibleSteps.index($targetStep) + 1;
         $root.find('.mpwem-wizard-progress').text('Step ' + current + ' of ' + $visibleSteps.length);
         $root.find('.mpwem-wizard-prev').prop('disabled', current === 1);
-        $root.find('.mpwem-wizard-next').text(current === $visibleSteps.length ? 'Save Event' : 'Next Step');
+        $root.find('.mpwem-wizard-next').text(current === $visibleSteps.length ? finalSaveLabel($root) : 'Next Step');
         $root.find('#mpwem_active_step').val(stepKey);
 
         if (options && options.pushHash) {
@@ -4849,7 +4862,7 @@
             const current = $visibleSteps.index($activeStep) + 1;
             $root.find('.mpwem-wizard-progress').text('Step ' + current + ' of ' + $visibleSteps.length);
             $root.find('.mpwem-wizard-prev').prop('disabled', current === 1);
-            $root.find('.mpwem-wizard-next').text(current === $visibleSteps.length ? 'Save Event' : 'Next Step');
+            $root.find('.mpwem-wizard-next').text(current === $visibleSteps.length ? finalSaveLabel($root) : 'Next Step');
         }
     }
 
@@ -5590,38 +5603,79 @@
 
         let error = null; // { message, $field, $flash }
 
-        const checkItemList = function(toggleName, containerId, itemSelector, titleName, addId, label, noun) {
+        // Sync any TinyMCE editors back to their textareas so the FAQ/Timeline
+        // descriptions can be read even while the visual editor is active.
+        if (window.tinymce && typeof window.tinymce.triggerSave === 'function') {
+            try { window.tinymce.triggerSave(); } catch (e) {}
+        }
+
+        // A wp_editor body counts as empty when it has no text once tags and
+        // non-breaking spaces are stripped (an "empty" editor is often <p></p>).
+        const isBlankHtml = function(value) {
+            return (value || '').toString().replace(/<[^>]*>/g, '').replace(/&nbsp;/gi, '').replace(/\s+/g, '') === '';
+        };
+
+        const checkItemList = function(toggleName, containerId, itemSelector, titleName, descName, addId, label, noun) {
             const $toggle = $root.find('input[name="' + toggleName + '"]').first();
             if (!$toggle.length || !$toggle.is(':checked')) return null;
 
-            // Require at least one item with a title. Blank rows are dropped on
-            // save, so they don't count and don't block on their own.
+            // Require at least one item, and every non-blank item needs BOTH a
+            // title and a description. Fully blank rows are dropped on save, so
+            // they don't block on their own.
             const $items = $root.find(containerId + ' ' + itemSelector);
-            let hasFilled = false;
-            let $firstTitle = $();
+            let started = 0;
+            let $errField = $();
+            let $errFlash = $();
+            let errMsg = '';
+
             $items.each(function() {
-                const $t = $(this).find('input[name="' + titleName + '"]').first();
-                if (!$firstTitle.length) $firstTitle = $t;
-                if (($t.val() || '').toString().trim() !== '') { hasFilled = true; }
+                const $item = $(this);
+                const $t = $item.find('input[name="' + titleName + '"]').first();
+                const $d = $item.find('[name="' + descName + '"]').first();
+                $t.removeClass('mpwem-field-error');
+                $d.removeClass('mpwem-field-error');
+
+                const titleVal = ($t.val() || '').toString().trim();
+                const descBlank = isBlankHtml($d.val());
+
+                if (titleVal === '' && descBlank) {
+                    return; // fully blank row — ignored
+                }
+                started++;
+                if (!$errField.length) {
+                    if (titleVal === '') {
+                        $t.addClass('mpwem-field-error');
+                        $errField = $t; $errFlash = $item;
+                        errMsg = label + ' is enabled — each ' + noun + ' needs a title.';
+                    } else if (descBlank) {
+                        $d.addClass('mpwem-field-error');
+                        $errField = $d; $errFlash = $item;
+                        errMsg = label + ' is enabled — each ' + noun + ' needs a description.';
+                    }
+                }
             });
 
-            if (!hasFilled) {
+            if (started === 0) {
+                const $firstTitle = $items.first().find('input[name="' + titleName + '"]').first();
                 if ($firstTitle.length) {
                     $firstTitle.addClass('mpwem-field-error');
-                    return { message: label + ' is enabled — add at least one ' + noun + '.', $field: $firstTitle, $flash: $firstTitle.closest(itemSelector) };
+                    return { message: label + ' is enabled — add at least one ' + noun + ' with a title and description.', $field: $firstTitle, $flash: $firstTitle.closest(itemSelector) };
                 }
                 const $add = $root.find(addId).first();
-                return { message: label + ' is enabled — add at least one ' + noun + '.', $field: $add, $flash: $add };
+                return { message: label + ' is enabled — add at least one ' + noun + ' with a title and description.', $field: $add, $flash: $add };
+            }
+            if ($errField.length) {
+                return { message: errMsg, $field: $errField, $flash: $errFlash };
             }
             return null;
         };
 
         // FAQ.
-        error = checkItemList('mep_faq_status', '#faq-items-container', '.faq-item', 'mep_faq_title[]', '#add-faq-item', 'FAQ', 'FAQ item');
+        error = checkItemList('mep_faq_status', '#faq-items-container', '.faq-item', 'mep_faq_title[]', 'mep_faq_content[]', '#add-faq-item', 'FAQ', 'FAQ item');
 
         // Timeline.
         if (!error) {
-            error = checkItemList('mep_timeline_status', '#timeline-items-container', '.timeline-item', 'mep_day_title[]', '#add-timeline-item', 'Timeline', 'timeline item');
+            error = checkItemList('mep_timeline_status', '#timeline-items-container', '.timeline-item', 'mep_day_title[]', 'mep_day_content[]', '#add-timeline-item', 'Timeline', 'timeline item');
         }
 
         // Related Events — when enabled, need a section label and at least one event.
@@ -5849,8 +5903,8 @@
                 date_order: 'The event End date & time must be later than the Start.',
                 repeat_periods: 'After Repeated Days must be a number of at least 1.',
                 date_format: 'Complete the Date/Time format settings (Date Format, Time Format and Show Timezone).',
-                faq_items: 'FAQ is enabled — add at least one FAQ item with a title.',
-                timeline_items: 'Timeline is enabled — add at least one timeline item with a title.',
+                faq_items: 'FAQ is enabled — each FAQ item needs a title and a description.',
+                timeline_items: 'Timeline is enabled — each timeline item needs a title and a description.',
                 related_label: 'Related Events is enabled — add a section label.',
                 related_list: 'Related Events is enabled — select at least one event.'
             };
@@ -5916,7 +5970,7 @@
                 if (!validateDateWiseGlobalQty($root)) {
                     return;
                 }
-                submitEventForm($root, '');
+                submitEventForm($root, finalSaveAction($root));
             }
         });
 

--- a/assets/admin/wc-payment-manager.js
+++ b/assets/admin/wc-payment-manager.js
@@ -71,7 +71,16 @@
 			} )
 				.done( function ( res ) {
 					if ( res && res.success ) {
-						applyEnabledState( $card, res.data.enabled === 'yes' );
+						// Reflect the gateway's REAL state — WooCommerce may have
+						// refused to enable it (e.g. unsupported store currency), in
+						// which case the checkbox snaps back and we explain why.
+						var reallyOn = !! ( res.data && res.data.enabled === 'yes' );
+						$input.prop( 'checked', reallyOn );
+						applyEnabledState( $card, reallyOn );
+						if ( res.data && res.data.notice ) {
+							window.alert( res.data.notice );
+						}
+						$( document ).trigger( 'mep:gateways-refresh' );
 					} else {
 						$input.prop( 'checked', ! $input.is( ':checked' ) );
 						window.alert( ( res && res.data ) || i18n.error );

--- a/includes/admin/class-wc-payment-manager.php
+++ b/includes/admin/class-wc-payment-manager.php
@@ -217,7 +217,38 @@ if ( ! class_exists( 'MPWEM_WC_Payment_Manager' ) ) :
 				WC()->payment_gateways()->init();
 			}
 
-			wp_send_json_success( [ 'enabled' => $enabled ] );
+			// WooCommerce can refuse to enable a gateway even after the option is
+			// saved — e.g. PayPal Standard force-disables itself for store currencies
+			// it doesn't support (BDT, etc.). Read the gateway back and report its
+			// REAL state instead of the requested one, so the toggle never shows a
+			// method as enabled that checkout cannot actually use.
+			$refreshed    = $this->get_gateway( $gateway_id );
+			$real_enabled = ( $refreshed && $refreshed->enabled === 'yes' ) ? 'yes' : 'no';
+			$response     = [ 'enabled' => $real_enabled ];
+
+			if ( 'yes' === $enabled && 'yes' !== $real_enabled ) {
+				// The enable did not take effect — don't leave a misleading saved
+				// flag that the banner/checkout would have to reconcile later.
+				$opts['enabled'] = 'no';
+				update_option( $option_key, $opts );
+
+				$name     = $refreshed ? ( $refreshed->get_method_title() ?: $refreshed->get_title() ) : $gateway_id;
+				$currency = function_exists( 'get_woocommerce_currency' ) ? get_woocommerce_currency() : '';
+				$response['notice'] = $currency
+					? sprintf(
+						/* translators: 1: gateway name, 2: store currency code */
+						__( '%1$s can\'t be enabled for your store currency (%2$s). Choose a gateway that supports %2$s.', 'mage-eventpress' ),
+						$name,
+						$currency
+					)
+					: sprintf(
+						/* translators: %s: gateway name */
+						__( '%s can\'t be enabled for your store right now.', 'mage-eventpress' ),
+						$name
+					);
+			}
+
+			wp_send_json_success( $response );
 		}
 
 		// ---------------------------------------------------------------


### PR DESCRIPTION
Builds on the merged event-wizard step-validation work.

## Payment configuration (Step 2)
- Offline custom gateway shows the **PRO** badge when PRO is inactive (matches PayPal/Stripe).
- When WooCommerce isn't active, hide the "Enable WooCommerce Payment Gateway" toggle and WC fields — only the install/activate notice shows.
- WooCommerce gateway toggle now reports the gateway's **real** post-save state and explains when WC refuses to enable it (e.g. PayPal Standard rejecting an unsupported store currency like BDT).
- Step-2 banner recognises the **Offline** gateway (`data-offline`), so enabling it clears "No Payment Method Enabled".
- WooCommerce and the custom (native checkout) gateways are **mutually exclusive**: enabling either side auto-disables the other (persisted server-side + live UI sync).
- Event Mode options reordered: **Ticket-Selling first, Listing-Only last**.

## Advanced step (Step 4)
- Final save button adapts to state: **Save & Publish Event** for a new/unpublished event (publishes), **Save & Update Event** for a published one (updates in place).
- FAQ and Timeline now require **both a title and a description** per item when the section is enabled (previously title-only); fully blank rows are still ignored.

## Files
- `admin/MPWEM_Event_Edit_Page.php`
- `admin/settings/MPWEM_Ticket_Price_Settings.php`
- `admin/settings/global/admin_setting_panel.php`
- `includes/admin/class-wc-payment-manager.php`
- `assets/admin/mpwem_event_edit.js`
- `assets/admin/wc-payment-manager.js`

🤖 Generated with [Claude Code](https://claude.com/claude-code)