### PR TITLE
perf(event-list): AJAX pagination + UX fixes for large event lists

### DIFF
--- a/admin/MPWEM_Event_Edit_Page.php
+++ b/admin/MPWEM_Event_Edit_Page.php
@@ -851,6 +851,14 @@ if (! class_exists('MPWEM_Event_Edit_Page')) {
 				return;
 			}
 
+			// Only hijack the actual "edit" screen. Other post.php actions
+			// (trash, untrash, delete, editpost, …) must reach WordPress so the
+			// delete/trash icons in the event list keep working.
+			$action = isset($_GET['action']) ? sanitize_key(wp_unslash($_GET['action'])) : 'edit';
+			if ($action !== 'edit') {
+				return;
+			}
+
 			$post_id = isset($_GET['post']) ? absint($_GET['post']) : 0;
 			if (! $post_id || get_post_type($post_id) !== self::POST_TYPE) {
 				return;

--- a/admin/MPWEM_Event_Lists.php
+++ b/admin/MPWEM_Event_Lists.php
@@ -13,6 +13,8 @@
 				add_action( 'admin_menu', array( $this, 'event_list_menu' ) );
 				add_action( 'admin_action_mpwem_duplicate_post', [ $this, 'mpwem_duplicate_post_function' ] );
 				add_action( 'wp_ajax_mpwem_trash_multiple_posts', [ $this, 'mpwem_trash_multiple_posts' ] );
+				add_action( 'wp_ajax_mpwem_load_event_list', array( $this, 'mpwem_load_event_list' ) );
+				add_action( 'wp_ajax_mpwem_dashboard_stats', array( $this, 'mpwem_dashboard_stats' ) );
 				add_action( 'wp_ajax_mpwem_quick_edit_event', array( $this, 'mpwem_quick_edit_event' ) );
 				add_action( 'wp_ajax_mpwem_popup_attendee_statistic', array( $this, 'mpwem_popup_attendee_statistic' ) );
 				add_action( 'wp_ajax_mpwem_load_popup_attendee_statistics', array( $this, 'mpwem_load_popup_attendee_statistics' ) );
@@ -31,53 +33,13 @@
 					'trash'   => isset( $counts->trash ) ? $counts->trash : 0,
 				);
 				$total_event = $post_counts['publish'] + $post_counts['draft'] + $post_counts['private'] + $post_counts['trash'];
-				//$statuses = ['publish', 'draft', 'trash'];
-				$statuses           = [ 'publish', 'draft', 'private' ];
-				$events             = get_posts( array(
-					'post_type'   => 'mep_events',
-					'post_status' => $statuses,
-					'numberposts' => - 1
-				) );
-				$event_status_count = get_active_expire_upcoming_count( $events );
+				// Active/Expired counts via cheap meta-compare queries instead of loading every event.
+				$event_status_count = mpwem_active_expire_count();
 				$post_type          = 'mep_events';
 				$add_new_link       = admin_url( 'post-new.php?post_type=' . $post_type );
 				$trash_url          = admin_url( 'edit.php?post_status=trash&post_type=mep_events' );
-				$order_status       = array( 'wc-completed', 'wc-processing' );
-				$total_registration = 0;
-				if ( MPWEM_Global_Function::has_woocommerce() ) {
-					$completed_orders   = wc_get_orders( [
-						'status' => $order_status,
-						'limit'  => - 1,
-						'return' => 'ids',
-					] );
-					$total_registration = count( $completed_orders );
-				} else {
-					$rsvp_attendees = get_posts( array(
-						'post_type'   => 'mep_events_attendees',
-						'numberposts' => -1,
-						'post_status' => 'publish',
-					) );
-					$total_registration = count( $rsvp_attendees );
-				}
-				$year               = date( 'Y' );
-				$month              = date( 'm' );
-				$prev_year          = $year;
-				$prev_month         = $month - 1;
-				if ( $month === 1 ) {
-					$prev_month = 12;
-					$prev_year  = $year - 1;
-				}
-				$currency                   = get_woocommerce_currency();
-				$currency_symbol            = get_woocommerce_currency_symbol( $currency );
-				$header_info                = get_monthly_revenue( $year, $month );
-				$prev_header_info           = get_monthly_revenue( $prev_year, $prev_month );
-				$current_month_revenue      = $header_info['revenue'];
-				$current_month_registration = $header_info['each_month_registration'];
-				$prev_month_revenue         = $prev_header_info['revenue'];
-				$prev_month_registration    = $prev_header_info['each_month_registration'];
-				$rev_change                 = $current_month_revenue - $prev_month_revenue;
-				$revenue_percent_change     = get_change_in_percent( $current_month_revenue, $prev_month_revenue );
-				$reg_percent_change         = get_change_in_percent( $current_month_registration, $prev_month_registration );
+				// Heavy, order-scanning analytics (registrations + revenue) are loaded asynchronously
+				// via the mpwem_dashboard_stats AJAX handler so the page can paint immediately.
 				$get_all_categories         = get_all_event_taxonomy( 'mep_cat' );
 				?>
                 <div class="wrap">
@@ -113,16 +75,14 @@
                                         <div class="trend neutral">→ <?php esc_html_e( 'Same as last week', 'mage-eventpress' ); ?></div>
                                     </div>
                                     <div class="analytics-card">
-                                        <h3><?php echo esc_html( $total_registration ); ?></h3>
+                                        <h3 id="mpwem_total_registration" class="mpwem-stat-loading">&hellip;</h3>
                                         <p><?php esc_html_e( 'Total Registrations', 'mage-eventpress' ); ?></p>
-                                        <div class="trend up">↗ <?php echo esc_html( $reg_percent_change['inc_dec_sign'] . '%' . $reg_percent_change['percent_change'] . ' vs last month' ); ?></div>
+                                        <div class="trend up" id="mpwem_registration_trend">&nbsp;</div>
                                     </div>
                                     <div class="analytics-card">
-                                        <h3><?php echo esc_html( $currency_symbol . ' ' . $current_month_revenue ); ?></h3>
+                                        <h3 id="mpwem_month_revenue" class="mpwem-stat-loading">&hellip;</h3>
                                         <p><?php esc_html_e( 'Revenue This Month', 'mage-eventpress' ); ?></p>
-                                        <div class="trend up">
-											<?php printf( '↗ %1$s%2$s%% vs last month', esc_html( $revenue_percent_change['inc_dec_sign'] ), esc_html( $revenue_percent_change['percent_change'] ) ); ?>
-                                        </div>
+                                        <div class="trend up" id="mpwem_revenue_trend">&nbsp;</div>
                                     </div>
                                 </div>
                                 <div class="stats-summary">
@@ -168,11 +128,11 @@
                                     <input id="mpwem_search_event_list" type="text" placeholder="<?php esc_attr_e( 'Search events, locations, or organizers...', 'mage-eventpress' ); ?>">
                                 </div>
                                 <select class="category-select" id="mpwem_event_filter_by_category">
-                                    <option><?php esc_html_e( 'All Categories', 'mage-eventpress' ); ?></option>
+                                    <option value=""><?php esc_html_e( 'All Categories', 'mage-eventpress' ); ?></option>
 									<?php
 										if ( is_array( $get_all_categories ) && ! empty( $get_all_categories ) ) {
 											foreach ( $get_all_categories as $key => $event_categories ) { ?>
-                                                <option><?php echo esc_html( $event_categories ); ?></option>
+                                                <option value="<?php echo esc_attr( $key ); ?>" data-slug="<?php echo esc_attr( $key ); ?>"><?php echo esc_html( $event_categories ); ?></option>
 											<?php }
 										}
 									?>
@@ -200,19 +160,42 @@
                                         <th><?php esc_html_e( 'Actions', 'mage-eventpress' ); ?></th>
                                     </tr>
                                     </thead>
-                                    <tbody>
-									<?php render_mep_events_by_status( $events ); ?>
+                                    <tbody id="mpwem_event_list_body">
+                                    <tr class="mpwem_event_list_loading_row">
+                                        <td colspan="9" style="text-align:center;padding:30px;">
+                                            <?php esc_html_e( 'Loading events…', 'mage-eventpress' ); ?>
+                                        </td>
+                                    </tr>
                                     </tbody>
                                 </table>
                             </div>
                             <div class="pagination">
-                                <div class="pagination-info">
-									<?php esc_html_e( 'Showing', 'mage-eventpress' ); ?> <span id="visibleCount">0</span> of <span id="totalCount">0</span> <?php esc_html_e( ' Events', 'mage-eventpress' ); ?>
+                                <div class="mpwem-pg-left">
+                                    <div class="pagination-info">
+										<?php esc_html_e( 'Showing', 'mage-eventpress' ); ?> <span id="visibleCount">0</span> of <span id="totalCount">0</span> <?php esc_html_e( ' Events', 'mage-eventpress' ); ?>
+                                    </div>
+                                    <div class="mpwem-perpage">
+                                        <label for="mpwem_per_page"><?php esc_html_e( 'Show', 'mage-eventpress' ); ?></label>
+                                        <select id="mpwem_per_page" class="mpwem-perpage-input">
+                                            <option value="10">10</option>
+                                            <option value="20">20</option>
+                                            <option value="50">50</option>
+                                            <option value="100">100</option>
+                                        </select>
+                                        <span><?php esc_html_e( 'events', 'mage-eventpress' ); ?></span>
+                                    </div>
                                 </div>
-                                <button class="load-more-btn" id="loadMoreBtn">
-                                    <span><?php esc_html_e( 'Load More Events', 'mage-eventpress' ); ?></span>
-                                    <span>↓</span>
-                                </button>
+                                <div class="mpwem-pagination-switch" id="mpwem_pagination_switch" role="tablist" aria-label="<?php esc_attr_e( 'Pagination mode', 'mage-eventpress' ); ?>">
+                                    <button type="button" class="mpwem-pg-mode" data-mode="loadmore"><?php esc_html_e( 'Load More', 'mage-eventpress' ); ?></button>
+                                    <button type="button" class="mpwem-pg-mode" data-mode="numbered"><?php esc_html_e( 'Numbered', 'mage-eventpress' ); ?></button>
+                                </div>
+                                <div class="mpwem-pg-right">
+                                    <button class="load-more-btn" id="loadMoreBtn">
+                                        <span><?php esc_html_e( 'Load More Events', 'mage-eventpress' ); ?></span>
+                                        <svg class="mpwem-pg-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 5v14"/><path d="M6 13l6 6 6-6"/></svg>
+                                    </button>
+                                    <div class="mpwem-numbered-pagination" id="mpwem_numbered_pagination"></div>
+                                </div>
                             </div>
                             <div class="mpPopup mpwem_popup_attendee_statistic" data-popup="mpwem_popup_attendee_statistic"></div>
                         </div>
@@ -241,6 +224,149 @@
 					}
 				}
 				wp_send_json_success( [ 'message' => 'Selected posts moved to trash successfully.' ] );
+			}
+			public function mpwem_load_event_list() {
+				if ( ! isset( $_POST['nonce'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['nonce'] ) ), 'mep_nonce' ) ) {
+					wp_send_json_error( array( 'message' => 'Security check failed' ) );
+				}
+				if ( ! current_user_can( 'edit_posts' ) ) {
+					wp_send_json_error( array( 'message' => 'Permission denied' ) );
+				}
+				$page          = isset( $_POST['page'] ) ? max( 1, absint( $_POST['page'] ) ) : 1;
+				$per_page      = isset( $_POST['per_page'] ) ? min( 100, max( 1, absint( $_POST['per_page'] ) ) ) : 20;
+				$search        = isset( $_POST['search'] ) ? sanitize_text_field( wp_unslash( $_POST['search'] ) ) : '';
+				$category      = isset( $_POST['category'] ) ? sanitize_text_field( wp_unslash( $_POST['category'] ) ) : '';
+				$date_from     = isset( $_POST['date_from'] ) ? sanitize_text_field( wp_unslash( $_POST['date_from'] ) ) : '';
+				$date_to       = isset( $_POST['date_to'] ) ? sanitize_text_field( wp_unslash( $_POST['date_to'] ) ) : '';
+				$status        = isset( $_POST['status'] ) ? sanitize_text_field( wp_unslash( $_POST['status'] ) ) : 'all';
+				$active_status = isset( $_POST['active_status'] ) ? sanitize_text_field( wp_unslash( $_POST['active_status'] ) ) : 'all';
+				$orderby       = isset( $_POST['orderby'] ) ? sanitize_text_field( wp_unslash( $_POST['orderby'] ) ) : '';
+				$order         = ( isset( $_POST['order'] ) && strtolower( $_POST['order'] ) === 'desc' ) ? 'DESC' : 'ASC';
+
+				$allowed_status = array( 'publish', 'draft', 'private' );
+				$post_status    = in_array( $status, $allowed_status, true ) ? array( $status ) : $allowed_status;
+
+				$args = array(
+					'post_type'      => 'mep_events',
+					'post_status'    => $post_status,
+					'posts_per_page' => $per_page,
+					'paged'          => $page,
+				);
+				if ( $search !== '' ) {
+					$args['s'] = $search;
+				}
+				$meta_query = array();
+				if ( $category !== '' ) {
+					$args['tax_query'] = array(
+						array(
+							'taxonomy' => 'mep_cat',
+							'field'    => 'slug',
+							'terms'    => $category,
+						),
+					);
+				}
+				if ( $date_from !== '' ) {
+					$meta_query[] = array(
+						'key'     => 'event_start_datetime',
+						'value'   => $date_from . ' 00:00:00',
+						'compare' => '>=',
+						'type'    => 'DATETIME',
+					);
+				}
+				if ( $date_to !== '' ) {
+					$meta_query[] = array(
+						'key'     => 'event_start_datetime',
+						'value'   => $date_to . ' 23:59:59',
+						'compare' => '<=',
+						'type'    => 'DATETIME',
+					);
+				}
+				if ( $active_status === 'active' || $active_status === 'expired' ) {
+					$now          = current_time( 'mysql' );
+					$meta_query[] = array(
+						'key'     => 'event_end_datetime',
+						'value'   => $now,
+						'compare' => ( $active_status === 'active' ) ? '>=' : '<',
+						'type'    => 'DATETIME',
+					);
+				}
+				if ( ! empty( $meta_query ) ) {
+					$meta_query['relation'] = 'AND';
+					$args['meta_query']     = $meta_query;
+				}
+				if ( $orderby === 'title' ) {
+					$args['orderby'] = 'title';
+					$args['order']   = $order;
+				} elseif ( $orderby === 'date' ) {
+					$args['orderby']  = 'meta_value';
+					$args['meta_key'] = 'event_start_datetime';
+					$args['meta_type'] = 'DATETIME';
+					$args['order']    = $order;
+				}
+
+				$query = new WP_Query( $args );
+				ob_start();
+				render_mep_events_by_status( $query->posts );
+				$html = ob_get_clean();
+
+				wp_send_json_success( array(
+					'html'      => $html,
+					'found'     => (int) $query->found_posts,
+					'max_pages' => (int) $query->max_num_pages,
+					'page'      => $page,
+				) );
+			}
+			public function mpwem_dashboard_stats() {
+				if ( ! isset( $_POST['nonce'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['nonce'] ) ), 'mep_nonce' ) ) {
+					wp_send_json_error( array( 'message' => 'Security check failed' ) );
+				}
+				if ( ! current_user_can( 'edit_posts' ) ) {
+					wp_send_json_error( array( 'message' => 'Permission denied' ) );
+				}
+				$order_status       = array( 'wc-completed', 'wc-processing' );
+				$total_registration = 0;
+				if ( MPWEM_Global_Function::has_woocommerce() ) {
+					$completed_orders   = wc_get_orders( array(
+						'status' => $order_status,
+						'limit'  => - 1,
+						'return' => 'ids',
+					) );
+					$total_registration = count( $completed_orders );
+				} else {
+					$rsvp_attendees     = get_posts( array(
+						'post_type'   => 'mep_events_attendees',
+						'numberposts' => - 1,
+						'post_status' => 'publish',
+					) );
+					$total_registration = count( $rsvp_attendees );
+				}
+				$year       = date( 'Y' );
+				$month      = date( 'm' );
+				$prev_year  = $year;
+				$prev_month = $month - 1;
+				if ( (int) $month === 1 ) {
+					$prev_month = 12;
+					$prev_year  = $year - 1;
+				}
+				$currency                   = get_woocommerce_currency();
+				// get_woocommerce_currency_symbol() returns an HTML entity (e.g. &#36;); decode it
+				// so the JSON carries the real glyph and JS .text() renders it correctly.
+				$currency_symbol            = html_entity_decode( get_woocommerce_currency_symbol( $currency ), ENT_QUOTES, 'UTF-8' );
+				$header_info                = get_monthly_revenue( $year, $month );
+				$prev_header_info           = get_monthly_revenue( $prev_year, $prev_month );
+				$current_month_revenue      = $header_info['revenue'];
+				$current_month_registration = $header_info['each_month_registration'];
+				$prev_month_revenue         = $prev_header_info['revenue'];
+				$prev_month_registration    = $prev_header_info['each_month_registration'];
+				$revenue_percent_change     = get_change_in_percent( $current_month_revenue, $prev_month_revenue );
+				$reg_percent_change         = get_change_in_percent( $current_month_registration, $prev_month_registration );
+
+				wp_send_json_success( array(
+					'total_registration' => $total_registration,
+					'revenue'            => $currency_symbol . ' ' . $current_month_revenue,
+					'registration_trend' => '↗ ' . $reg_percent_change['inc_dec_sign'] . '%' . $reg_percent_change['percent_change'] . ' vs last month',
+					'revenue_trend'      => sprintf( '↗ %1$s%2$s%% vs last month', $revenue_percent_change['inc_dec_sign'], $revenue_percent_change['percent_change'] ),
+				) );
 			}
 			function mpwem_duplicate_post_function() {
 				if ( ! isset( $_GET['post_id'] ) || ! isset( $_GET['_wpnonce'] ) ||
@@ -431,6 +557,40 @@
 			}
 		}
 		new MPWEM_Event_Lists();
+	}
+	function mpwem_active_expire_count() {
+		$now    = current_time( 'mysql' );
+		$base   = array(
+			'post_type'      => 'mep_events',
+			'post_status'    => array( 'publish', 'draft', 'private' ),
+			'posts_per_page' => 1,
+			'fields'         => 'ids',
+			'no_found_rows'  => false,
+		);
+		$active = new WP_Query( array_merge( $base, array(
+			'meta_query' => array(
+				array(
+					'key'     => 'event_end_datetime',
+					'value'   => $now,
+					'compare' => '>=',
+					'type'    => 'DATETIME',
+				),
+			),
+		) ) );
+		$expire = new WP_Query( array_merge( $base, array(
+			'meta_query' => array(
+				array(
+					'key'     => 'event_end_datetime',
+					'value'   => $now,
+					'compare' => '<',
+					'type'    => 'DATETIME',
+				),
+			),
+		) ) );
+		return array(
+			'active_count' => (int) $active->found_posts,
+			'expire_count' => (int) $expire->found_posts,
+		);
 	}
 	function get_active_expire_upcoming_count( $events ) {
 		$active_count   = 0;
@@ -780,21 +940,11 @@
                     <td>
                         <div class="actions">
 							<?php do_action( 'mep_before_dashboard_event_list', $id ); ?>
-                            <a href="<?php echo esc_url( $view_link ); ?>">
-                                <button class="action-btn view" title="View Event"><span class="mi mi-eye"></span></button>
-                            </a>
-                            <a href="#">
-                                <button class="action-btn quick-edit" title="Quick Edit" data-event-id="<?php echo esc_attr( $id ); ?>"><span class="mi mi-file-edit"></span></button>
-                            </a>
-                            <a href="<?php echo esc_url( $edit_link ); ?>">
-                                <button class="action-btn edit" title="Edit Event"><span class="mi mi-pencil"></span></button>
-                            </a>
-                            <a href="#" data-mpwem_popup_attendee_statistic="mpwem_popup_attendee_statistic" data-event-id="<?php echo esc_attr( $id ); ?>">
-                                <button class="action-btn"><i class="mi mi-stats"></i></button>
-                            </a>
-                            <a href="<?php echo esc_url( $delete_link ); ?>">
-                                <button class="action-btn delete" title="Delete Event"><span class="mi mi-trash"></span></button>
-                            </a>
+                            <a href="<?php echo esc_url( $view_link ); ?>" class="action-btn view" title="View Event"><span class="mi mi-eye"></span></a>
+                            <a href="#" class="action-btn quick-edit" title="Quick Edit" data-event-id="<?php echo esc_attr( $id ); ?>"><span class="mi mi-file-edit"></span></a>
+                            <a href="<?php echo esc_url( $edit_link ); ?>" class="action-btn edit" title="Edit Event"><span class="mi mi-pencil"></span></a>
+                            <a href="#" class="action-btn" data-mpwem_popup_attendee_statistic="mpwem_popup_attendee_statistic" data-event-id="<?php echo esc_attr( $id ); ?>" title="<?php esc_attr_e( 'Attendee Statistics', 'mage-eventpress' ); ?>"><i class="mi mi-stats"></i></a>
+                            <a href="<?php echo esc_url( $delete_link ); ?>" class="action-btn delete" title="Delete Event"><span class="mi mi-trash"></span></a>
 							<?php do_action( 'mep_after_dashboard_event_list', $id ); ?>
                         </div>
                     </td>

--- a/assets/admin/mpwem_event_lists.css
+++ b/assets/admin/mpwem_event_lists.css
@@ -575,6 +575,11 @@
     justify-content: center;
     width: 32px;
     height: 32px;
+    text-decoration: none;
+    box-sizing: border-box;
+}
+.mpwem_event_list .action-btn:hover {
+    text-decoration: none;
 }
 .mpwem_event_list .action-btn.view {
     color: #3b82f6;
@@ -706,4 +711,319 @@
         flex-direction: row;
         align-items: stretch;
     }
+}
+
+/* Deferred analytics placeholder (filled by AJAX) */
+.mpwem-stat-loading {
+    opacity: 0.35;
+    letter-spacing: 2px;
+}
+.mpwem_event_list_loading_row td {
+    color: #6b7280;
+    font-style: italic;
+}
+
+/* ===== Pagination bar (single row, matches design) ===== */
+.mpwem_event_list .pagination {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+    gap: 16px;
+    flex-wrap: wrap;
+    background: #fff;
+    border: 1px solid #eceef2;
+    border-radius: 12px;
+    padding: 14px 20px;
+    text-align: left;
+}
+.mpwem-pg-left {
+    display: flex;
+    align-items: center;
+    gap: 18px;
+    flex-wrap: wrap;
+}
+.mpwem_event_list .pagination .pagination-info {
+    margin: 0;
+    font-size: 13px;
+    color: #6b7280;
+    text-align: left;
+}
+
+/* "Show N events" per-page select */
+.mpwem-perpage {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 13px;
+    color: #6b7280;
+}
+.mpwem-perpage-input {
+    height: 36px;
+    padding: 0 30px 0 12px;
+    border: 1px solid #e3e6ec;
+    border-radius: 8px;
+    background-color: #fff;
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='%236b7280' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M6 9l6 6 6-6'/%3E%3C/svg%3E");
+    background-repeat: no-repeat;
+    background-position: right 10px center;
+    background-size: 12px;
+    font-size: 13px;
+    font-weight: 600;
+    color: #374151;
+    line-height: 36px;
+    cursor: pointer;
+    -webkit-appearance: none;
+    -moz-appearance: none;
+    appearance: none;
+}
+.mpwem-perpage-input:focus {
+    outline: none;
+    border-color: #2563eb;
+    box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.15);
+}
+
+/* Segmented switch (lavender track, inset white capsule, bold blue text) */
+.mpwem_event_list .mpwem-pagination-switch {
+    display: inline-flex;
+    align-items: center;
+    gap: 0;
+    padding: 6px;
+    background: #e8e6f3;
+    border-radius: 999px;
+    border: none;
+    box-shadow: none;
+}
+.mpwem_event_list .mpwem-pagination-switch .mpwem-pg-mode {
+    -webkit-appearance: none;
+    -moz-appearance: none;
+    appearance: none;
+    margin: 0;
+    border: none;
+    outline: none;
+    background: transparent;
+    color: #5b616e;
+    padding: 11px 32px;
+    font-size: 14px;
+    font-weight: 600;
+    line-height: 1;
+    height: auto;
+    min-height: 0;
+    cursor: pointer;
+    border-radius: 999px;
+    box-shadow: none;
+    transition: color 0.2s ease, background 0.2s ease, box-shadow 0.2s ease;
+    white-space: nowrap;
+}
+.mpwem_event_list .mpwem-pagination-switch .mpwem-pg-mode:hover {
+    color: #374151;
+    background: transparent;
+}
+.mpwem_event_list .mpwem-pagination-switch .mpwem-pg-mode:focus {
+    outline: none;
+    box-shadow: none;
+}
+.mpwem_event_list .mpwem-pagination-switch .mpwem-pg-mode.active,
+.mpwem_event_list .mpwem-pagination-switch .mpwem-pg-mode.active:hover,
+.mpwem_event_list .mpwem-pagination-switch .mpwem-pg-mode.active:focus {
+    background: #ffffff;
+    color: #2563eb;
+    font-weight: 700;
+    box-shadow: 0 3px 8px rgba(33, 49, 84, 0.18);
+}
+
+/* Right group + Load More button */
+.mpwem-pg-right {
+    display: inline-flex;
+    align-items: center;
+}
+.mpwem-pg-icon {
+    width: 17px;
+    height: 17px;
+    flex: 0 0 auto;
+}
+.mpwem_event_list .load-more-btn {
+    padding: 9px 24px;
+    border-radius: 10px;
+    font-weight: 600;
+}
+.mpwem_event_list .load-more-btn:hover {
+    border-color: #bcd0ff;
+    background: #eff4ff;
+    color: #2563eb;
+}
+
+/* Numbered pager */
+.mpwem-numbered-pagination {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    flex-wrap: wrap;
+}
+.mpwem-pg-btn {
+    min-width: 36px;
+    height: 36px;
+    padding: 0 9px;
+    border: none;
+    background: transparent;
+    color: #374151;
+    font-size: 13px;
+    font-weight: 600;
+    cursor: pointer;
+    border-radius: 8px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    transition: background 0.16s ease, color 0.16s ease, border-color 0.16s ease;
+}
+.mpwem-pg-btn:hover:not(.disabled):not(.dots):not(.active) {
+    background: #f1f3f9;
+    color: #2563eb;
+}
+.mpwem-pg-btn.active {
+    background: #2563eb;
+    color: #fff;
+    cursor: default;
+    box-shadow: 0 2px 6px rgba(37, 99, 235, 0.35);
+}
+.mpwem-pg-btn.nav {
+    border: 1px solid #e3e6ec;
+    background: #fff;
+    color: #6b7280;
+}
+.mpwem-pg-btn.nav:hover:not(.disabled) {
+    background: #f1f3f9;
+    color: #2563eb;
+    border-color: #bcd0ff;
+}
+.mpwem-pg-btn.nav .mpwem-pg-icon {
+    width: 16px;
+    height: 16px;
+}
+.mpwem-pg-btn.disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+}
+.mpwem-pg-btn.dots {
+    background: transparent;
+    cursor: default;
+    min-width: 18px;
+    color: #9ca3af;
+}
+
+@media (max-width: 782px) {
+    .mpwem_event_list .pagination {
+        justify-content: center;
+    }
+    .mpwem-pg-left {
+        justify-content: center;
+        width: 100%;
+    }
+}
+
+/* ===== Confirmation modal ===== */
+body.mpwem-modal-open {
+    overflow: hidden;
+}
+.mpwem-modal-overlay {
+    position: fixed;
+    inset: 0;
+    z-index: 100000;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 20px;
+    background: rgba(17, 24, 39, 0.55);
+    backdrop-filter: blur(3px);
+    -webkit-backdrop-filter: blur(3px);
+    opacity: 0;
+    visibility: hidden;
+    transition: opacity 0.2s ease, visibility 0.2s ease;
+}
+.mpwem-modal-overlay.is-open {
+    opacity: 1;
+    visibility: visible;
+}
+.mpwem-modal {
+    width: 100%;
+    max-width: 420px;
+    background: #fff;
+    border-radius: 18px;
+    padding: 32px 28px 26px;
+    text-align: center;
+    box-shadow: 0 24px 60px rgba(15, 23, 42, 0.28);
+    transform: translateY(12px) scale(0.96);
+    opacity: 0;
+    transition: transform 0.24s cubic-bezier(0.34, 1.56, 0.64, 1), opacity 0.24s ease;
+}
+.mpwem-modal-overlay.is-open .mpwem-modal {
+    transform: translateY(0) scale(1);
+    opacity: 1;
+}
+.mpwem-modal__icon {
+    width: 68px;
+    height: 68px;
+    margin: 0 auto 18px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 50%;
+    color: #dc2626;
+    background: #fee2e2;
+}
+.mpwem-modal__icon svg {
+    width: 32px;
+    height: 32px;
+}
+.mpwem-modal__title {
+    margin: 0 0 10px;
+    font-size: 20px;
+    font-weight: 700;
+    color: #111827;
+    line-height: 1.3;
+}
+.mpwem-modal__text {
+    margin: 0 0 26px;
+    font-size: 14px;
+    line-height: 1.6;
+    color: #6b7280;
+}
+.mpwem-modal__actions {
+    display: flex;
+    gap: 12px;
+    justify-content: center;
+}
+.mpwem-modal__btn {
+    flex: 1 1 0;
+    min-width: 0;
+    padding: 12px 18px;
+    border-radius: 12px;
+    font-size: 14px;
+    font-weight: 600;
+    cursor: pointer;
+    border: 1px solid transparent;
+    transition: background 0.18s ease, border-color 0.18s ease, color 0.18s ease, transform 0.05s ease;
+}
+.mpwem-modal__btn:active {
+    transform: translateY(1px);
+}
+.mpwem-modal__btn--cancel {
+    background: #f3f4f6;
+    color: #374151;
+    border-color: #e5e7eb;
+}
+.mpwem-modal__btn--cancel:hover {
+    background: #e5e7eb;
+}
+.mpwem-modal__btn--confirm {
+    background: linear-gradient(135deg, #ef4444 0%, #dc2626 100%);
+    color: #fff;
+    box-shadow: 0 6px 16px rgba(220, 38, 38, 0.35);
+}
+.mpwem-modal__btn--confirm:hover {
+    background: linear-gradient(135deg, #dc2626 0%, #b91c1c 100%);
+}
+.mpwem-modal__btn:focus-visible {
+    outline: 2px solid #2563eb;
+    outline-offset: 2px;
 }

--- a/assets/admin/mpwem_event_lists.js
+++ b/assets/admin/mpwem_event_lists.js
@@ -1,150 +1,437 @@
 (function ($) {
 
+    const DEFAULT_PER_PAGE = 20;
+    const PAGINATION_MODE_KEY = 'mpwem_pagination_mode';
+    const PER_PAGE_KEY = 'mpwem_per_page';
 
-    // Filter by category
-    $('#mpwem_event_filter_by_category').on('change', function() {
-        applyFilters();
-    });
+    function getSavedPaginationMode() {
+        try {
+            let m = window.localStorage.getItem(PAGINATION_MODE_KEY);
+            return (m === 'numbered' || m === 'loadmore') ? m : 'loadmore';
+        } catch (e) {
+            return 'loadmore';
+        }
+    }
 
-    // Search events
-    $('#mpwem_search_event_list').on('keyup', function() {
-        applyFilters();
-    });
+    function clampPerPage(n) {
+        n = parseInt(n, 10);
+        if (isNaN(n) || n < 1) { return DEFAULT_PER_PAGE; }
+        return Math.min(100, n);
+    }
 
-    // Filter by date range
-    $('#mpwem_date_from, #mpwem_date_to').on('change', function() {
-        applyFilters();
-    });
+    function getSavedPerPage() {
+        try {
+            return clampPerPage(window.localStorage.getItem(PER_PAGE_KEY));
+        } catch (e) {
+            return DEFAULT_PER_PAGE;
+        }
+    }
 
-    // Clear date filter
-    $('#mpwem_clear_date_filter').on('click', function() {
-        $('#mpwem_date_from').val('');
-        $('#mpwem_date_to').val('');
-        applyFilters();
-    });
+    const state = {
+        page: 1,
+        perPage: getSavedPerPage(),
+        search: '',
+        category: '',
+        dateFrom: '',
+        dateTo: '',
+        status: 'all',
+        activeStatus: 'all',
+        orderby: '',
+        order: 'asc',
+        maxPages: 1,
+        found: 0,
+        loading: false,
+        paginationMode: getSavedPaginationMode() // 'loadmore' | 'numbered'
+    };
 
-    // Combined filter function
-    function applyFilters() {
-        var selectedCategory = $('#mpwem_event_filter_by_category').val().toLowerCase();
-        var searchTerm = $('#mpwem_search_event_list').val().toLowerCase().trim();
-        var dateFrom = $('#mpwem_date_from').val();
-        var dateTo = $('#mpwem_date_to').val();
-        
-        var fromTimestamp = dateFrom ? new Date(dateFrom + 'T00:00:00').getTime() / 1000 : null;
-        var toTimestamp = dateTo ? new Date(dateTo + 'T23:59:59').getTime() / 1000 : null;
-        
-        $('.mpwem_event_list_card').each(function() {
-            var eventCategory = $(this).data('filter-by-category').toLowerCase();
-            var eventName = $(this).data('filter-by-event-name').toLowerCase();
-            var eventOrganiser = $(this).data('filter-by-event-organiser').toLowerCase();
-            var eventDate = parseInt($(this).data('event-date'));
-            
-            // Category filter
-            var showByCategory = selectedCategory === 'all categories' || eventCategory.includes(selectedCategory);
-            
-            // Search filter
-            var showBySearch = searchTerm === '' || eventName.includes(searchTerm) || eventOrganiser.includes(searchTerm) || eventCategory.includes(searchTerm);
-            
-            // Date filter
-            var showByDate = true;
-            if (fromTimestamp && eventDate < fromTimestamp) {
-                showByDate = false;
-            }
-            if (toTimestamp && eventDate > toTimestamp) {
-                showByDate = false;
-            }
-            
-            // Show/hide based on all filters
-            if (showByCategory && showBySearch && showByDate) {
-                $(this).show();
-            } else {
-                $(this).hide();
+    const $body = $('#mpwem_event_list_body');
+
+    function debounce(fn, wait) {
+        let t;
+        return function () {
+            const ctx = this, args = arguments;
+            clearTimeout(t);
+            t = setTimeout(function () { fn.apply(ctx, args); }, wait);
+        };
+    }
+
+    // Recalculate capacity bars for the given scope (defaults to whole table body).
+    function renderCapacityBars($scope) {
+        $scope = $scope || $body;
+        $scope.find('.mpwem_event_list_capacity').each(function () {
+            let capacityNumber = $(this).find('.mpwem_event_list_capacity-number').text().trim(); // e.g. "600/600"
+            let parts = capacityNumber.split('/');
+            if (parts.length === 2) {
+                let current = parseFloat(parts[0]);
+                let total = parseFloat(parts[1]);
+                if (!isNaN(current) && !isNaN(total) && total > 0) {
+                    let percent = (current / total) * 100;
+                    percent = Math.min(percent, 100); // max 100%
+
+                    let $fill = $(this).find('.mpwem_event_list_capacity-fill');
+                    $fill.css('width', percent + '%');
+
+                    if (percent >= 100) {
+                        $fill.css('background-color', '#dc3545'); // red when full
+                        $(this).find('.mpwem_event_list_capacity-status').text('Full').css('color', '#dc3545');
+                    } else {
+                        $fill.css('background-color', '#28a745');
+                        $(this).find('.mpwem_event_list_capacity-status').text('Available').css('color', '#28a745');
+                    }
+                }
             }
         });
     }
 
-
-
-    /*const mpwem_itemsPerPage = 2;
-    let mpwem_totalItems = $('.mpwem_event_list_card').length;
-    let mpwem_visibleItems = 0;
-    $('#totalCount').text(mpwem_totalItems);
-    $('.mpwem_event_list_card').hide();
-    function showMoreItems() {
-        let hiddenItems = $('.mpwem_event_list_card:hidden');
-        let itemsToShow = hiddenItems.slice(0, mpwem_itemsPerPage);
-        itemsToShow.show();
-        mpwem_visibleItems = $('.mpwem_event_list_card:visible').length;
-        $('#visibleCount').text(mpwem_visibleItems);
-
-        // Hide load more button if all items are visible
-        if (mpwem_visibleItems >= mpwem_totalItems) {
-            $('#loadMoreBtn').hide();
-        }
+    // Reset to page 1 and reload (filters/search/sort/mode changed).
+    function reloadEvents() {
+        state.page = 1;
+        fetchEvents(false);
     }
-    showMoreItems();
-    $(document).on('click', '#loadMoreBtn', function() {
-        showMoreItems();
-    });*/
 
-    const itemsPerPage = 20;
-    let currentFilteredItems = $('.mpwem_event_list_card');
-    let totalVisible = 0;
-    function showNextItems() {
-        let hiddenItems = currentFilteredItems.filter(':hidden');
-        hiddenItems.slice(0, itemsPerPage).fadeIn();
+    // Fetch a page of events from the server. append = add rows; otherwise replace tbody.
+    function fetchEvents(append) {
+        if (state.loading) {
+            return;
+        }
+        state.loading = true;
+        $('#loadMoreBtn').prop('disabled', true);
 
-        let currentlyVisible = currentFilteredItems.filter(':visible').length;
-        $('#visibleCount').text(currentlyVisible);
-        $('#totalCount').text(currentFilteredItems.length);
+        if (!append) {
+            $body.html('<tr class="mpwem_event_list_loading_row"><td colspan="9" style="text-align:center;padding:30px;">Loading events…</td></tr>');
+        }
 
-        // Hide Load More button if all items are shown
-        if (currentlyVisible >= currentFilteredItems.length) {
+        $.ajax({
+            url: mep_ajax.url,
+            type: 'POST',
+            data: {
+                action: 'mpwem_load_event_list',
+                nonce: mep_ajax.nonce,
+                page: state.page,
+                per_page: state.perPage,
+                search: state.search,
+                category: state.category,
+                date_from: state.dateFrom,
+                date_to: state.dateTo,
+                status: state.status,
+                active_status: state.activeStatus,
+                orderby: state.orderby,
+                order: state.order
+            },
+            success: function (response) {
+                if (!response || !response.success) {
+                    $body.html('<tr><td colspan="9" style="text-align:center;padding:30px;">Unable to load events.</td></tr>');
+                    return;
+                }
+                const data = response.data;
+                state.maxPages = Math.max(1, data.max_pages);
+                state.found = data.found;
+
+                if (append) {
+                    $body.append(data.html || '');
+                } else if (!data.html || $.trim(data.html) === '') {
+                    $body.html('<tr><td colspan="9" style="text-align:center;padding:30px;">No events found.</td></tr>');
+                } else {
+                    $body.html(data.html);
+                }
+
+                updatePaginationUI();
+                renderCapacityBars($body);
+            },
+            error: function () {
+                if (!append) {
+                    $body.html('<tr><td colspan="9" style="text-align:center;padding:30px;">An error occurred while loading events.</td></tr>');
+                }
+            },
+            complete: function () {
+                state.loading = false;
+                $('#loadMoreBtn').prop('disabled', false);
+            }
+        });
+    }
+
+    // Update "Showing X of Y", the Load More button and the numbered nav per mode.
+    function updatePaginationUI() {
+        let visible = $body.find('.mpwem_event_list_card').length;
+        $('#visibleCount').text(visible);
+        $('#totalCount').text(state.found);
+
+        if (state.paginationMode === 'numbered') {
             $('#loadMoreBtn').hide();
+            renderNumberedPagination();
         } else {
-            $('#loadMoreBtn').show();
+            $('#mpwem_numbered_pagination').empty();
+            if (state.page >= state.maxPages || visible >= state.found) {
+                $('#loadMoreBtn').hide();
+            } else {
+                $('#loadMoreBtn').show();
+            }
         }
     }
-    function initialLoad() {
-        $('.mpwem_event_list_card').hide();
-        currentFilteredItems = $('.mpwem_event_list_card');
-        showNextItems();
+
+    // Build a windowed numbered pager: « ‹ 1 … 4 5 [6] 7 8 … 20 › »
+    function renderNumberedPagination() {
+        const $nav = $('#mpwem_numbered_pagination');
+        const total = state.maxPages;
+        const cur = state.page;
+        $nav.empty();
+        if (total <= 1) {
+            return;
+        }
+
+        const chevronLeft = '<svg class="mpwem-pg-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M15 18l-6-6 6-6"/></svg>';
+        const chevronRight = '<svg class="mpwem-pg-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M9 18l6-6-6-6"/></svg>';
+
+        function btn(label, page, opts) {
+            opts = opts || {};
+            let $b = $('<button type="button" class="mpwem-pg-btn"></button>').html(label);
+            if (opts.nav) { $b.addClass('nav'); }
+            if (opts.active) { $b.addClass('active'); }
+            if (opts.disabled) { $b.addClass('disabled').prop('disabled', true); }
+            if (opts.dots) { $b.addClass('dots').prop('disabled', true); }
+            if (!opts.disabled && !opts.dots && page) { $b.attr('data-page', page); }
+            return $b;
+        }
+
+        $nav.append(btn(chevronLeft, cur - 1, { nav: true, disabled: cur <= 1 }));
+
+        let pages = [];
+        const windowSize = 2; // pages on each side of current
+        for (let i = 1; i <= total; i++) {
+            if (i === 1 || i === total || (i >= cur - windowSize && i <= cur + windowSize)) {
+                pages.push(i);
+            }
+        }
+        let prev = 0;
+        pages.forEach(function (p) {
+            if (prev && p - prev > 1) {
+                $nav.append(btn('…', 0, { dots: true }));
+            }
+            $nav.append(btn(String(p), p, { active: p === cur }));
+            prev = p;
+        });
+
+        $nav.append(btn(chevronRight, cur + 1, { nav: true, disabled: cur >= total }));
     }
-    initialLoad();
-    $('#loadMoreBtn').on('click', function() {
-        showNextItems();
+
+    // Highlight the active pagination-mode button.
+    function syncPaginationSwitch() {
+        $('.mpwem-pg-mode').removeClass('active');
+        $('.mpwem-pg-mode[data-mode="' + state.paginationMode + '"]').addClass('active');
+    }
+
+    // Deferred heavy analytics (registrations + revenue).
+    function loadDashboardStats() {
+        $.ajax({
+            url: mep_ajax.url,
+            type: 'POST',
+            data: {
+                action: 'mpwem_dashboard_stats',
+                nonce: mep_ajax.nonce
+            },
+            success: function (response) {
+                if (!response || !response.success) {
+                    return;
+                }
+                const d = response.data;
+                $('#mpwem_total_registration').removeClass('mpwem-stat-loading').text(d.total_registration);
+                $('#mpwem_month_revenue').removeClass('mpwem-stat-loading').text(d.revenue);
+                $('#mpwem_registration_trend').text(d.registration_trend);
+                $('#mpwem_revenue_trend').text(d.revenue_trend);
+            }
+        });
+    }
+
+    /* ------------------------------------------------------------------ */
+    /* Filters / search / sort -> reset & reload from the server           */
+    /* ------------------------------------------------------------------ */
+
+    $('#mpwem_event_filter_by_category').on('change', function () {
+        // Option value is the category slug ('' = All Categories).
+        state.category = $(this).val() || '';
+        reloadEvents();
     });
+
+    $('#mpwem_search_event_list').on('keyup', debounce(function () {
+        state.search = $(this).val().trim();
+        reloadEvents();
+    }, 350));
+
+    // "Show N events" per-page select (persisted)
+    $('#mpwem_per_page').on('change', function () {
+        let val = clampPerPage($(this).val());
+        state.perPage = val;
+        try { window.localStorage.setItem(PER_PAGE_KEY, val); } catch (e) {}
+        reloadEvents();
+    });
+
+    $('#mpwem_date_from, #mpwem_date_to').on('change', function () {
+        state.dateFrom = $('#mpwem_date_from').val();
+        state.dateTo = $('#mpwem_date_to').val();
+        reloadEvents();
+    });
+
+    $('#mpwem_clear_date_filter').on('click', function () {
+        $('#mpwem_date_from').val('');
+        $('#mpwem_date_to').val('');
+        state.dateFrom = '';
+        state.dateTo = '';
+        reloadEvents();
+    });
+
     $(document).on('click', '.mpwem_filter_by_status', function () {
         $('.mpwem_filter_by_status').removeClass('mpwem_filter_btn_active_bg_color').addClass('mpwem_filter_btn_bg_color');
         $(this).removeClass('mpwem_filter_btn_bg_color').addClass('mpwem_filter_btn_active_bg_color');
+        // Reset the active/expired chips when switching post-status.
+        $('.mpwem_filter_by_active_status').removeClass('mpwem_filter_btn_active_bg_color');
 
-        let searchText = $(this).attr('data-by-filter').toLowerCase();
-        $('.mpwem_event_list_card').hide();
-        currentFilteredItems = $('.mpwem_event_list_card').filter(function () {
-            let status = $(this).data('event-status').toLowerCase();
-            return (searchText === 'all' || status.includes(searchText));
-        });
-        // Reset counter and show first N
-        $('#visibleCount').text(0);
-        showNextItems();
+        state.status = $(this).attr('data-by-filter').toLowerCase();
+        state.activeStatus = 'all';
+        reloadEvents();
     });
 
     $(document).on('click', '.mpwem_filter_by_active_status', function () {
         $('.mpwem_filter_by_active_status').removeClass('mpwem_filter_btn_active_bg_color').addClass('mpwem_filter_btn_bg_color');
         $(this).removeClass('mpwem_filter_btn_bg_color').addClass('mpwem_filter_btn_active_bg_color');
 
-        let searchText = $(this).attr('data-by-filter').toLowerCase();
-        $('.mpwem_event_list_card').hide();
-        currentFilteredItems = $('.mpwem_event_list_card').filter(function () {
-            let status = $(this).data('event-active-status').toLowerCase();
-            return (searchText === 'all' || status.includes(searchText));
-        });
-        // Reset counter and show first N
-        $('#visibleCount').text(0);
-        showNextItems();
+        state.activeStatus = $(this).attr('data-by-filter').toLowerCase();
+        reloadEvents();
     });
 
-    $(document).on('click', '#mpwem_select_all_post', function() {
+    // Sorting -> server-side
+    $('.sortable').on('click', function () {
+        let sortBy = $(this).data('sort'); // 'title' or 'date'
+        let newDirection = (state.orderby === sortBy && state.order === 'asc') ? 'desc' : 'asc';
+        state.orderby = sortBy;
+        state.order = newDirection;
+
+        $('.sort-indicator').removeClass('asc desc');
+        $(this).find('.sort-indicator').addClass(newDirection);
+
+        reloadEvents();
+    });
+
+    // Load more -> next page, append
+    $('#loadMoreBtn').on('click', function () {
+        if (state.page < state.maxPages) {
+            state.page++;
+            fetchEvents(true);
+        }
+    });
+
+    // Numbered pagination -> jump to page, replace rows
+    $(document).on('click', '#mpwem_numbered_pagination .mpwem-pg-btn', function () {
+        let page = parseInt($(this).attr('data-page'), 10);
+        if (!page || page === state.page) {
+            return;
+        }
+        state.page = page;
+        fetchEvents(false);
+        // Keep the table in view when jumping pages.
+        if ($('.table-container').length) {
+            $('html, body').animate({ scrollTop: $('.table-container').offset().top - 60 }, 200);
+        }
+    });
+
+    // Pagination mode switch (persisted in localStorage)
+    $(document).on('click', '.mpwem-pg-mode', function () {
+        let mode = $(this).attr('data-mode');
+        if (mode === state.paginationMode) {
+            return;
+        }
+        state.paginationMode = mode;
+        try { window.localStorage.setItem(PAGINATION_MODE_KEY, mode); } catch (e) {}
+        syncPaginationSwitch();
+        reloadEvents();
+    });
+
+    /* ------------------------------------------------------------------ */
+    /* Modern confirmation modal                                           */
+    /* ------------------------------------------------------------------ */
+
+    function buildConfirmModal() {
+        if ($('#mpwem_confirm_modal').length) {
+            return $('#mpwem_confirm_modal');
+        }
+        let html =
+            '<div class="mpwem-modal-overlay" id="mpwem_confirm_modal" aria-hidden="true">' +
+            '  <div class="mpwem-modal" role="dialog" aria-modal="true" aria-labelledby="mpwem_modal_title">' +
+            '    <div class="mpwem-modal__icon">' +
+            '      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M3 6h18"/><path d="M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/><path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6"/><path d="M10 11v6"/><path d="M14 11v6"/></svg>' +
+            '    </div>' +
+            '    <h3 class="mpwem-modal__title" id="mpwem_modal_title"></h3>' +
+            '    <p class="mpwem-modal__text"></p>' +
+            '    <div class="mpwem-modal__actions">' +
+            '      <button type="button" class="mpwem-modal__btn mpwem-modal__btn--cancel"></button>' +
+            '      <button type="button" class="mpwem-modal__btn mpwem-modal__btn--confirm"></button>' +
+            '    </div>' +
+            '  </div>' +
+            '</div>';
+        return $(html).appendTo('body');
+    }
+
+    // Show the modal. opts: { title, text, confirmText, cancelText, onConfirm }
+    function mpwemConfirm(opts) {
+        opts = opts || {};
+        let $modal = buildConfirmModal();
+        $modal.find('.mpwem-modal__title').text(opts.title || 'Are you sure?');
+        $modal.find('.mpwem-modal__text').text(opts.text || '');
+        $modal.find('.mpwem-modal__btn--confirm').text(opts.confirmText || 'Yes, delete');
+        $modal.find('.mpwem-modal__btn--cancel').text(opts.cancelText || 'Cancel');
+
+        function close() {
+            $modal.removeClass('is-open').attr('aria-hidden', 'true');
+            $(document).off('keydown.mpwemConfirm');
+            setTimeout(function () { $('body').removeClass('mpwem-modal-open'); }, 200);
+        }
+
+        $modal.find('.mpwem-modal__btn--confirm').off('click').on('click', function () {
+            close();
+            if (typeof opts.onConfirm === 'function') { opts.onConfirm(); }
+        });
+        $modal.find('.mpwem-modal__btn--cancel').off('click').on('click', close);
+        // Click on the dimmed backdrop closes; clicks inside the card do not.
+        $modal.off('click').on('click', function (e) {
+            if (e.target === this) { close(); }
+        });
+        $(document).on('keydown.mpwemConfirm', function (e) {
+            if (e.key === 'Escape') { close(); }
+        });
+
+        $('body').addClass('mpwem-modal-open');
+        // Force reflow so the open transition runs.
+        $modal.attr('aria-hidden', 'false')[0].offsetWidth;
+        $modal.addClass('is-open');
+        $modal.find('.mpwem-modal__btn--confirm').focus();
+    }
+
+    // Intercept the delete (trash) icon and confirm first.
+    $(document).on('click', '.action-btn.delete', function (e) {
+        e.preventDefault();
+        let href = $(this).attr('href');
+        if (!href || href === '#') {
+            return;
+        }
+        let $row = $(this).closest('tr.mpwem_event_list_card');
+        let title = ($row.data('event-title') || '').toString().trim();
+        mpwemConfirm({
+            title: 'Delete this event?',
+            text: title
+                ? 'Are you sure you want to move "' + title + '" to Trash? You can restore it later from Trash.'
+                : 'Are you sure you want to move this event to Trash? You can restore it later from Trash.',
+            confirmText: 'Yes, delete',
+            cancelText: 'Cancel',
+            onConfirm: function () {
+                window.location.href = href;
+            }
+        });
+    });
+
+    /* ------------------------------------------------------------------ */
+    /* Bulk select / trash (unchanged, uses event delegation)              */
+    /* ------------------------------------------------------------------ */
+
+    $(document).on('click', '#mpwem_select_all_post', function () {
         let isChecked = $(this).prop('checked');
         $('.mpwem_select_single_post').prop('checked', isChecked);
         if (isChecked) {
@@ -155,7 +442,7 @@
     });
 
     // When any single checkbox is clicked
-    $(document).on('click', '.mpwem_select_single_post', function() {
+    $(document).on('click', '.mpwem_select_single_post', function () {
 
         let total = $('.mpwem_select_single_post').length;
         let checked = $('.mpwem_select_single_post:checked').length;
@@ -169,16 +456,16 @@
 
     });
 
-    $(document).on('click', '#mpwem_multiple_trash_btn', function(e) {
+    $(document).on('click', '#mpwem_multiple_trash_btn', function (e) {
         e.preventDefault();
-        let nonce = $('#mpwem_multiple_trash_nonce').val(); 
+        let nonce = $('#mpwem_multiple_trash_nonce').val();
         if (!nonce || !mep_ajax || !mep_ajax.nonce) {
             alert('Nonce is missing or invalid.');
             return;
         }
 
         let selectedIDs = [];
-        $('.mpwem_select_single_post:checked').each(function() {
+        $('.mpwem_select_single_post:checked').each(function () {
             let idAttr = $(this).attr('id');
             let postId = idAttr.split('_').pop();
             selectedIDs.push(postId);
@@ -189,95 +476,36 @@
             return;
         }
 
-        $.ajax({
-            url: mep_ajax .url,
-            type: 'POST',
-            data: {
-                action: 'mpwem_trash_multiple_posts',
-                post_ids: selectedIDs,
-                nonce: nonce
-            },
-            success: function(response) {
-                alert(response.data.message);
-                location.reload();
-            },
-            error: function() {
-                alert('An error occurred while trashing posts.');
+        mpwemConfirm({
+            title: 'Delete selected events?',
+            text: 'Are you sure you want to move ' + selectedIDs.length + ' selected event' + (selectedIDs.length > 1 ? 's' : '') + ' to Trash? You can restore them later from Trash.',
+            confirmText: 'Yes, delete',
+            cancelText: 'Cancel',
+            onConfirm: function () {
+                $.ajax({
+                    url: mep_ajax.url,
+                    type: 'POST',
+                    data: {
+                        action: 'mpwem_trash_multiple_posts',
+                        post_ids: selectedIDs,
+                        nonce: nonce
+                    },
+                    success: function () {
+                        location.reload();
+                    },
+                    error: function () {
+                        alert('An error occurred while trashing posts.');
+                    }
+                });
             }
         });
     });
 
-    $('.mpwem_event_list_capacity').each(function() {
-        let capacityNumber = $(this).find('.mpwem_event_list_capacity-number').text().trim(); // e.g. "600/600"
-        let parts = capacityNumber.split('/');
-        if(parts.length === 2) {
-            let current = parseFloat(parts[0]);
-            let total = parseFloat(parts[1]);
-            if (!isNaN(current) && !isNaN(total) && total > 0) {
-                let percent = (current / total) * 100;
-                percent = Math.min(percent, 100); // max 100%
+    /* ------------------------------------------------------------------ */
+    /* Quick Edit (unchanged, uses event delegation)                       */
+    /* ------------------------------------------------------------------ */
 
-                let $fill = $(this).find('.mpwem_event_list_capacity-fill');
-                $fill.css('width', percent + '%');
-
-                if (percent >= 100) {
-                    $fill.css('background-color', '#dc3545'); // red when full
-                    $(this).find('.mpwem_event_list_capacity-status').text('Full').css('color', '#dc3545');
-                } else {
-                    $fill.css('background-color', '#28a745');
-                    $(this).find('.mpwem_event_list_capacity-status').text('Available').css('color', '#28a745');
-                }
-            }
-        }
-    });
-
-    // Sorting functionality
-    let sortDirection = {};
-    $('.sortable').on('click', function() {
-        let sortBy = $(this).data('sort');
-        let currentDirection = sortDirection[sortBy] || 'asc';
-        let newDirection = currentDirection === 'asc' ? 'desc' : 'asc';
-        sortDirection[sortBy] = newDirection;
-
-        // Update sort indicators
-        $('.sort-indicator').removeClass('asc desc');
-        $(this).find('.sort-indicator').addClass(newDirection);
-
-        // Sort the table rows
-        let $tbody = $('.event-table tbody');
-        let $rows = $tbody.find('.mpwem_event_list_card').get();
-
-        $rows.sort(function(a, b) {
-            let aVal, bVal;
-            
-            if (sortBy === 'date') {
-                aVal = parseInt($(a).data('event-date'));
-                bVal = parseInt($(b).data('event-date'));
-            } else if (sortBy === 'title') {
-                aVal = $(a).data('event-title').toLowerCase();
-                bVal = $(b).data('event-title').toLowerCase();
-            }
-
-            if (newDirection === 'asc') {
-                return aVal > bVal ? 1 : aVal < bVal ? -1 : 0;
-            } else {
-                return aVal < bVal ? 1 : aVal > bVal ? -1 : 0;
-            }
-        });
-
-        // Re-append sorted rows (along with their quick-edit rows)
-        $.each($rows, function(index, row) {
-            let $row = $(row);
-            let $quickEditRow = $row.next('.quick-edit-row');
-            $tbody.append($row);
-            if ($quickEditRow.length) {
-                $tbody.append($quickEditRow);
-            }
-        });
-    });
-
-    // Quick Edit functionality - Only for custom event lists page
-    $(document).on('click', '.action-btn.quick-edit', function(e) {
+    $(document).on('click', '.action-btn.quick-edit', function (e) {
         e.preventDefault();
         let $row = $(this).closest('tr');
         // If triggered from the icon, $row may be the <tr> or a <div> inside <td>
@@ -291,13 +519,13 @@
         // Show this quick edit row and hide the main row
         $row.hide();
         $quickEditRow.show();
-        
+
         // Only handle custom quick edit on the custom event lists page
         if (!$('.mpwem_event_list').length) {
             return;
         }
         // Ensure dropdowns are properly initialized
-        $quickEditRow.find('select').each(function() {
+        $quickEditRow.find('select').each(function () {
             $(this).prop('disabled', false);
             $(this).css({
                 'pointer-events': 'auto',
@@ -308,37 +536,37 @@
         // Focus on first input
         $quickEditRow.find('input[name="post_title"]').focus();
     });
-    
+
     // Ensure dropdown functionality
-    $(document).on('click', '.quick-edit-row select', function(e) {
+    $(document).on('click', '.quick-edit-row select', function (e) {
         e.stopPropagation();
         $(this).focus();
     });
-    
-    $(document).on('mousedown', '.quick-edit-row select', function(e) {
+
+    $(document).on('mousedown', '.quick-edit-row select', function (e) {
         e.stopPropagation();
     });
 
     // Cancel quick edit
-    $(document).on('click', '.quick-edit-row .cancel', function() {
+    $(document).on('click', '.quick-edit-row .cancel', function () {
         let $quickEditRow = $(this).closest('.quick-edit-row');
         let $mainRow = $quickEditRow.prev('.mpwem_event_list_card');
-        
+
         $quickEditRow.hide();
         $mainRow.show();
     });
 
     // Save quick edit
-    $(document).on('click', '.quick-edit-row .save', function() {
+    $(document).on('click', '.quick-edit-row .save', function () {
         let $button = $(this);
         let $quickEditRow = $button.closest('.quick-edit-row');
         let $mainRow = $quickEditRow.prev('.mpwem_event_list_card');
         let eventId = $quickEditRow.data('event-id');
-        
+
         // Show spinner
         $quickEditRow.find('.spinner').addClass('is-active');
         $button.prop('disabled', true);
-        
+
         // Collect form data
         let formData = {
             action: 'mpwem_quick_edit_event',
@@ -351,12 +579,12 @@
             mep_cat: $quickEditRow.find('select[name="mep_cat[]"]').val() || [],
             nonce: $quickEditRow.find('.mep-quick-edit-nonce').val()
         };
-        
+
         $.ajax({
             url: mep_ajax.url,
             type: 'POST',
             data: formData,
-            success: function(response) {
+            success: function (response) {
                 if (response.success) {
                     // Update the main row with new data
                     location.reload(); // Simple reload for now
@@ -364,16 +592,30 @@
                     alert('Error: ' + (response.data.message || 'Unknown error occurred'));
                 }
             },
-            error: function() {
+            error: function () {
                 alert('An error occurred while saving the event.');
             },
-            complete: function() {
+            complete: function () {
                 $quickEditRow.find('.spinner').removeClass('is-active');
                 $button.prop('disabled', false);
             }
         });
     });
 
-
+    /* ------------------------------------------------------------------ */
+    /* Init                                                                */
+    /* ------------------------------------------------------------------ */
+    $(function () {
+        let $pp = $('#mpwem_per_page');
+        $pp.val(String(state.perPage));
+        // If the saved value isn't one of the select options, fall back to the default.
+        if ($pp.val() === null) {
+            state.perPage = DEFAULT_PER_PAGE;
+            $pp.val(String(DEFAULT_PER_PAGE));
+        }
+        syncPaginationSwitch();
+        loadDashboardStats();
+        reloadEvents();
+    });
 
 }(jQuery));

--- a/inc/MPWEM_Dependencies.php
+++ b/inc/MPWEM_Dependencies.php
@@ -189,12 +189,14 @@
 				wp_localize_script( 'mkb-admin', 'mep_ajax_var', array( 'url' => admin_url( 'admin-ajax.php' ), 'nonce' => wp_create_nonce( 'mep-ajax-nonce' ) ) );
 				// Only load event lists scripts on relevant pages
 				if ( $hook == 'mep_events_page_mep_event_lists' || ( isset( $_GET['post_type'] ) && $_GET['post_type'] == 'mep_events' && ( $hook == 'edit.php' || isset( $_GET['page'] ) && $_GET['page'] == 'mep_event_lists' ) ) ) {
-					wp_enqueue_script( 'mpwem_event_lists', MPWEM_PLUGIN_URL . '/assets/admin/mpwem_event_lists.js', array( 'jquery' ), MPWEM_PLUGIN_VERSION, true );
+					$mpwem_el_js_ver  = file_exists( MPWEM_PLUGIN_DIR . '/assets/admin/mpwem_event_lists.js' ) ? filemtime( MPWEM_PLUGIN_DIR . '/assets/admin/mpwem_event_lists.js' ) : MPWEM_PLUGIN_VERSION;
+					$mpwem_el_css_ver = file_exists( MPWEM_PLUGIN_DIR . '/assets/admin/mpwem_event_lists.css' ) ? filemtime( MPWEM_PLUGIN_DIR . '/assets/admin/mpwem_event_lists.css' ) : MPWEM_PLUGIN_VERSION;
+					wp_enqueue_script( 'mpwem_event_lists', MPWEM_PLUGIN_URL . '/assets/admin/mpwem_event_lists.js', array( 'jquery' ), $mpwem_el_js_ver, true );
 					wp_localize_script( 'mpwem_event_lists', 'mep_ajax', array(
 						'url'   => admin_url( 'admin-ajax.php' ),
 						'nonce' => wp_create_nonce( 'mep_nonce' )
 					) );
-					wp_enqueue_style( 'mpwem_event_lists', MPWEM_PLUGIN_URL . '/assets/admin/mpwem_event_lists.css', array(), MPWEM_PLUGIN_VERSION );
+					wp_enqueue_style( 'mpwem_event_lists', MPWEM_PLUGIN_URL . '/assets/admin/mpwem_event_lists.css', array(), $mpwem_el_css_ver );
 				}
 				/******************************/
 				// custom


### PR DESCRIPTION
## Summary

Reworks the **Event Lists** admin page (`edit.php?post_type=mep_events&page=mep_event_lists`) so it scales to thousands of events. Previously it loaded **every** event and rendered all rows server-side (two `<tr>` each, with ~15 meta/term/ticket queries per event), so clients with 2000+ events hit timeouts and fatal errors.

## What changed

**Performance**
- Rows now load via **AJAX with server-side pagination** (`mpwem_load_event_list`), including server-side search, category/date filters, and sorting — across the full dataset, not just loaded rows.
- The order-scanning analytics cards (Revenue / Total Registrations) are **deferred to a background request** (`mpwem_dashboard_stats`) so the page paints immediately.
- Active/Expired counts use **cheap count queries** instead of looping every event.

**UX**
- **Load More / Numbered** pagination toggle (choice persisted in `localStorage`) plus a **"Show N events"** per-page selector.
- A **modern confirmation modal** before deleting (single trash icon + bulk trash), replacing the native dialog.
- Pagination bar restyled to match the agreed design (single row, segmented switch, numbered pager).

**Bug fixes**
- **Delete icon opened the editor instead of trashing.** Root cause: `maybe_redirect_edit_screen()` (hooked on `load-post.php`) redirected *any* `post.php?post=ID` for a `mep_events` post into the wizard without checking the action, so the `action=trash` link got hijacked. Now guarded to `action=edit` only.
- Flattened the invalid `<a><button>…</button></a>` action markup into single `<a>` elements so AJAX-injected rows keep each link bound to its own action.

**Infra**
- `filemtime()`-based cache-busting for the event-list JS/CSS so asset edits always reach the browser.

## Files
- `admin/MPWEM_Event_Lists.php` — AJAX handlers, light page render, count helper, flattened action markup
- `admin/MPWEM_Event_Edit_Page.php` — guard wizard redirect to `action=edit`
- `assets/admin/mpwem_event_lists.js` — AJAX load/filter/sort, pagination modes, per-page, delete modal
- `assets/admin/mpwem_event_lists.css` — pagination switch/pager, per-page select, confirmation modal
- `inc/MPWEM_Dependencies.php` — filemtime asset versioning

## Test plan
- With 2000+ events, the list page paints instantly and loads the first page via `admin-ajax.php?action=mpwem_load_event_list` (no timeout).
- Load More appends; Numbered jumps pages; search / category / date / status / active filters and sort headers all re-query server-side.
- Revenue + Registrations cards populate shortly after load.
- Trash icon shows the confirm modal, then moves the event to Trash (no longer opens the editor); bulk trash confirms too.
- Quick Edit, multi-select, and the attendee-statistics popup still work on AJAX-loaded rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
