### PR TITLE
Include native (custom-payment) order revenue in Event Lists stats

### DIFF
--- a/admin/MPWEM_Event_Lists.php
+++ b/admin/MPWEM_Event_Lists.php
@@ -732,6 +732,12 @@
 		$start_date             = "$year-$month-01 00:00:00";
 		$end_date               = date( 'Y-m-t 23:59:59', strtotime( $start_date ) );
 
+		// Native (custom-payment) order revenue for the month. These mep_custom_order
+		// records are independent of WooCommerce, so they must be counted whether or
+		// not WooCommerce is active. Paid statuses mirror WooCommerce's processing +
+		// completed (native "completed" is the post status "publish").
+		$native_revenue = mpwem_native_orders_revenue( $start_date, $end_date );
+
 		if ( ! MPWEM_Global_Function::has_woocommerce() ) {
 			$rsvp_attendees = get_posts( array(
 				'post_type'   => 'mep_events_attendees',
@@ -746,7 +752,7 @@
 				),
 			) );
 			return array(
-				'revenue'                 => 0,
+				'revenue'                 => $native_revenue,
 				'each_month_registration' => count( $rsvp_attendees ),
 			);
 		}
@@ -767,9 +773,39 @@
 			}
 		}
 		return array(
-			'revenue'                 => $total,
+			'revenue'                 => $total + $native_revenue,
 			'each_month_registration' => $each_month_order_count,
 		);
+	}
+	/**
+	 * Sum the order totals of paid native (custom-payment) orders created within a
+	 * date range. Paid = post status "processing" or "publish" (native Completed),
+	 * mirroring WooCommerce's processing + completed revenue statuses.
+	 *
+	 * @param string $start_date 'Y-m-d H:i:s'
+	 * @param string $end_date   'Y-m-d H:i:s'
+	 * @return float
+	 */
+	function mpwem_native_orders_revenue( $start_date, $end_date ) {
+		$native_orders = get_posts( array(
+			'post_type'      => 'mep_custom_order',
+			'post_status'    => array( 'processing', 'publish' ),
+			'posts_per_page' => -1,
+			'fields'         => 'ids',
+			'no_found_rows'  => true,
+			'date_query'     => array(
+				array(
+					'after'     => $start_date,
+					'before'    => $end_date,
+					'inclusive' => true,
+				),
+			),
+		) );
+		$total = 0;
+		foreach ( $native_orders as $order_id ) {
+			$total += (float) get_post_meta( $order_id, '_mep_order_total', true );
+		}
+		return $total;
 	}
 	function get_change_in_percent( $current_month, $prev_month ) {
 		$change = $current_month - $prev_month;


### PR DESCRIPTION
get_monthly_revenue() only summed WooCommerce orders, and in the no-WooCommerce branch it returned 0 — so the dashboard "Revenue This Month" ignored all native custom-payment (mep_custom_order) income.

Add mpwem_native_orders_revenue(): sums the _mep_order_total of paid native orders (post status processing or publish/Completed, mirroring WooCommerce's processing + completed) created in the month. It is added to the revenue in both branches, so custom-payment revenue is counted whether or not WooCommerce is active.

Stacked on fix/event-list-hide-pagination-switch.