### PR TITLE
Single Event: no date dropdown, use first start/end date

### DIFF
--- a/templates/layout/date_select.php
+++ b/templates/layout/date_select.php
@@ -31,7 +31,11 @@
 					$date = $date_type == 'no' ? get_post_meta( $event_id, 'event_start_datetime', true ) : $date;
 
 					$date_format = MPWEM_Global_Function::check_time_exit_date( $date ) ? 'full' : 'date';
-					if ( is_array( $all_dates ) && sizeof( $all_dates ) == 1 ) {
+					// A Single Event ('no') is never date-selectable: the booking always uses
+					// the first row's start/end date, so render a hidden input even when the
+					// event has additional dates (those still appear in the Event Schedule
+					// Details sidebar). Only Particular Events ('yes') get the date dropdown.
+					if ( $date_type == 'no' || ( is_array( $all_dates ) && sizeof( $all_dates ) == 1 ) ) {
 						?>
                         <input type="hidden" id="mpwem_date_time" name='mpwem_date_time' value='<?php echo esc_attr( $date ); ?>'/>
 					<?php } else { ?>


### PR DESCRIPTION
A Single Event ('mep_enable_recurring' = 'no') is meant to be non date-selectable — the booking always uses the first row's start/end date. But if the event carried additional dates in mep_event_more_date (e.g. after being switched from a Particular Event), the frontend ticket selector rendered a "Select Date" dropdown because it only used the hidden-input path when exactly one date existed.

Render the hidden date input whenever the type is 'no', regardless of how many dates exist, so a Single Event is never date-selectable. Only Particular Events ('yes') get the dropdown.

The extra dates are intentionally left untouched, so they still appear in the "Event Schedule Details" sidebar (that list is unchanged).