### PR TITLE
Unify registration + revenue counts across all report pages (Woo + na…

### DIFF
--- a/admin/MPWEM_Event_Lists.php
+++ b/admin/MPWEM_Event_Lists.php
@@ -391,23 +391,10 @@
 				if ( ! current_user_can( 'edit_posts' ) ) {
 					wp_send_json_error( array( 'message' => 'Permission denied' ) );
 				}
-				$order_status       = array( 'wc-completed', 'wc-processing' );
-				$total_registration = 0;
-				if ( MPWEM_Global_Function::has_woocommerce() ) {
-					$completed_orders   = wc_get_orders( array(
-						'status' => $order_status,
-						'limit'  => - 1,
-						'return' => 'ids',
-					) );
-					$total_registration = count( $completed_orders );
-				} else {
-					$rsvp_attendees     = get_posts( array(
-						'post_type'   => 'mep_events_attendees',
-						'numberposts' => - 1,
-						'post_status' => 'publish',
-					) );
-					$total_registration = count( $rsvp_attendees );
-				}
+				// Total registrations = paid attendees/tickets across BOTH WooCommerce and
+				// native (custom-payment) orders. Counted uniformly from the attendee records
+				// that both flows create, so custom-payment bookings are always included.
+				$total_registration = MPWEM_Functions::registration_stats()['tickets'];
 				$year       = date( 'Y' );
 				$month      = date( 'm' );
 				$prev_year  = $year;
@@ -729,52 +716,17 @@
 		if ( ! $month ) {
 			$month = date( 'm' );
 		}
-		$start_date             = "$year-$month-01 00:00:00";
-		$end_date               = date( 'Y-m-t 23:59:59', strtotime( $start_date ) );
+		$start_date = "$year-$month-01 00:00:00";
+		$end_date   = date( 'Y-m-t 23:59:59', strtotime( $start_date ) );
 
-		// Native (custom-payment) order revenue for the month. These mep_custom_order
-		// records are independent of WooCommerce, so they must be counted whether or
-		// not WooCommerce is active. Paid statuses mirror WooCommerce's processing +
-		// completed (native "completed" is the post status "publish").
-		$native_revenue = mpwem_native_orders_revenue( $start_date, $end_date );
+		// Single source of truth: paid attendees/tickets for the month across BOTH
+		// WooCommerce and native (custom-payment) orders. See
+		// MPWEM_Functions::registration_stats().
+		$stats = MPWEM_Functions::registration_stats( $start_date, $end_date );
 
-		if ( ! MPWEM_Global_Function::has_woocommerce() ) {
-			$rsvp_attendees = get_posts( array(
-				'post_type'   => 'mep_events_attendees',
-				'numberposts' => -1,
-				'post_status' => 'publish',
-				'date_query'  => array(
-					array(
-						'after'     => $start_date,
-						'before'    => $end_date,
-						'inclusive' => true,
-					),
-				),
-			) );
-			return array(
-				'revenue'                 => $native_revenue,
-				'each_month_registration' => count( $rsvp_attendees ),
-			);
-		}
-
-		$order_status           = array( 'wc-completed', 'wc-processing' );
-		$orders                 = wc_get_orders( [
-			'limit'        => - 1,
-			'status'       => $order_status,
-			'date_created' => $start_date . '...' . $end_date,
-			'return'       => 'ids',
-		] );
-		$total                  = 0;
-		$each_month_order_count = count( $orders );
-		foreach ( $orders as $order_id ) {
-			$order = wc_get_order( $order_id );
-			if ( $order ) {
-				$total += $order->get_total();
-			}
-		}
 		return array(
-			'revenue'                 => $total + $native_revenue,
-			'each_month_registration' => $each_month_order_count,
+			'revenue'                 => $stats['revenue'],
+			'each_month_registration' => $stats['tickets'],
 		);
 	}
 	/**

--- a/admin/mep_analytics.php
+++ b/admin/mep_analytics.php
@@ -270,71 +270,59 @@ function mep_analytics_collect_from_attendees( $events, $start_ts, $end_ts, $sta
 			'total_sales'  => 0,
 			'dates'        => array(),
 		);
-		$seen = array();
+
+		// Count uniformly from the attendee records that BOTH WooCommerce and native
+		// (custom-payment) checkout create, filtered by the paid ea_order_status set — so
+		// custom-payment bookings are always included. Tickets = ea_ticket_qty; sales =
+		// ea_ticket_order_amount. This matches MPWEM_Functions::registration_stats() so the
+		// Analytics figures agree with the Event Lists / Sales Report pages.
+		$paid_statuses = class_exists( 'MPWEM_Functions' ) ? MPWEM_Functions::paid_order_statuses() : $statuses;
 
 		foreach ( $attendees as $attendee ) {
-			$aid       = $attendee->ID;
-			$order_id  = get_post_meta( $aid, 'ea_order_id', true );
-			$t_type    = get_post_meta( $aid, 'ea_ticket_type', true );
-			$e_date    = get_post_meta( $aid, 'ea_event_date', true );
-			$t_price   = get_post_meta( $aid, 'ea_ticket_price', true );
-			$t_price   = is_numeric( $t_price ) ? floatval( $t_price ) : 0;
-
-			$order_date_ts = get_the_date( 'U', $attendee );
-
-			if ( ! empty( $order_id ) && MPWEM_Global_Function::has_woocommerce() ) {
-				$unique_key = $order_id . '_' . $eid . '_' . $e_date . '_' . $t_type;
-				if ( isset( $seen[ $unique_key ] ) ) {
-					continue;
-				}
-				$seen[ $unique_key ] = true;
-
-				$order = wc_get_order( $order_id );
-				if ( $order ) {
-					$order_status = $order->get_status();
-					if ( ! in_array( $order_status, $statuses, true ) ) {
-						continue;
-					}
-
-					$order_date_obj = $order->get_date_created();
-					if ( $order_date_obj ) {
-						$order_date_ts = $order_date_obj->getTimestamp();
-					}
-				} else {
-					continue;
-				}
-			} else {
-				$unique_key = 'rsvp_' . $aid;
-				if ( isset( $seen[ $unique_key ] ) ) {
-					continue;
-				}
-				$seen[ $unique_key ] = true;
+			$aid    = $attendee->ID;
+			$status = get_post_meta( $aid, 'ea_order_status', true );
+			if ( ! in_array( $status, $paid_statuses, true ) ) {
+				continue;
 			}
 
+			$order_date_ts = (int) get_the_date( 'U', $attendee );
 			if ( $order_date_ts < $start_ts || $order_date_ts > $end_ts ) {
 				continue;
 			}
 
+			$t_type = get_post_meta( $aid, 'ea_ticket_type', true );
+			$e_date = get_post_meta( $aid, 'ea_event_date', true );
+			$qty    = (float) get_post_meta( $aid, 'ea_ticket_qty', true );
+			if ( $qty <= 0 ) {
+				$qty = 1;
+			}
+			$amount = get_post_meta( $aid, 'ea_ticket_order_amount', true );
+			if ( ! is_numeric( $amount ) ) {
+				$price  = get_post_meta( $aid, 'ea_ticket_price', true );
+				$amount = ( is_numeric( $price ) ? floatval( $price ) : 0 ) * $qty;
+			}
+			$amount = floatval( $amount );
+
 			// Aggregate
-			$data['tickets_sold'] ++;
-			$data['total_sales'] += $t_price;
-			$event_data['tickets_sold'] ++;
-			$event_data['total_sales'] += $t_price;
+			$data['tickets_sold'] += $qty;
+			$data['total_sales'] += $amount;
+			$event_data['tickets_sold'] += $qty;
+			$event_data['total_sales'] += $amount;
 
 			$date_fmt = date( 'Y-m-d', $order_date_ts );
-			$data['sales_by_date'][ $date_fmt ] = ( $data['sales_by_date'][ $date_fmt ] ?? 0 ) + $t_price;
+			$data['sales_by_date'][ $date_fmt ] = ( $data['sales_by_date'][ $date_fmt ] ?? 0 ) + $amount;
 
 			$weekday = date( 'l', $order_date_ts );
-			$data['sales_by_weekday'][ $weekday ] = ( $data['sales_by_weekday'][ $weekday ] ?? 0 ) + $t_price;
+			$data['sales_by_weekday'][ $weekday ] = ( $data['sales_by_weekday'][ $weekday ] ?? 0 ) + $amount;
 
 			$type_label = $t_type ?: 'General';
-			$data['ticket_types'][ $type_label ] = ( $data['ticket_types'][ $type_label ] ?? 0 ) + 1;
+			$data['ticket_types'][ $type_label ] = ( $data['ticket_types'][ $type_label ] ?? 0 ) + $qty;
 
 			if ( ! isset( $event_data['dates'][ $e_date ] ) ) {
 				$event_data['dates'][ $e_date ] = array( 'tickets_sold' => 0, 'total_sales' => 0 );
 			}
-			$event_data['dates'][ $e_date ]['tickets_sold'] ++;
-			$event_data['dates'][ $e_date ]['total_sales'] += $t_price;
+			$event_data['dates'][ $e_date ]['tickets_sold'] += $qty;
+			$event_data['dates'][ $e_date ]['total_sales'] += $amount;
 		}
 
 		$data['tickets_by_event'][ $event_title ] = $event_data['tickets_sold'];
@@ -539,6 +527,21 @@ function mep_get_analytics_data() {
 		$raw = mep_analytics_collect_from_attendees( $events, $start_ts, $end_ts, $statuses );
 	} else {
 		$raw = mep_analytics_collect_from_orders( $events, $start_ts, $end_ts, $statuses );
+	}
+
+	// Headline summary uses the canonical, payment-source-agnostic totals (WooCommerce +
+	// native) so the Analytics cards match the Event Lists and Sales Report pages exactly.
+	// The per-event charts below remain a distribution of the currently published events.
+	// Skipped when a category filter is active, which the canonical query does not scope.
+	if ( '' === $category && class_exists( 'MPWEM_Functions' ) ) {
+		$canon                   = MPWEM_Functions::registration_stats(
+			date( 'Y-m-d H:i:s', $start_ts ),
+			date( 'Y-m-d H:i:s', $end_ts ),
+			( 'all' === $event_id ? 0 : (int) $event_id )
+		);
+		$raw['tickets_sold']     = $canon['tickets'];
+		$raw['total_sales']      = $canon['revenue'];
+		$raw['avg_ticket_price'] = $canon['tickets'] > 0 ? round( $canon['revenue'] / $canon['tickets'], 2 ) : 0;
 	}
 
 	// Sort sales by date

--- a/inc/MPWEM_Functions.php
+++ b/inc/MPWEM_Functions.php
@@ -222,6 +222,87 @@
 				}
 				return $price;
 			}
+			/**
+			 * Paid attendee order statuses (normalised, no "wc-" prefix).
+			 *
+			 * Both WooCommerce and native (custom-payment) checkout write these to each
+			 * attendee's `ea_order_status`, so filtering on them is payment-source agnostic.
+			 * Mirrors the configured "Seat Reserved Order Status" plus partially-paid.
+			 *
+			 * @return string[]
+			 */
+			public static function paid_order_statuses(): array {
+				$set = mep_get_option( 'seat_reserved_order_status', 'general_setting_sec', array( 'processing', 'completed' ) );
+				$set = is_array( $set ) && ! empty( $set ) ? array_values( $set ) : array( 'processing', 'completed' );
+				$set = array_map( static function ( $s ) {
+					return strpos( (string) $s, 'wc-' ) === 0 ? substr( $s, 3 ) : $s;
+				}, $set );
+				$set[] = 'partially-paid';
+				$set[] = 'completed'; // native "completed" bookings.
+				return array_values( array_unique( array_filter( $set ) ) );
+			}
+			/**
+			 * Canonical registration + revenue totals, counted uniformly from the
+			 * mep_events_attendees records that BOTH WooCommerce and native checkout create.
+			 *
+			 * This is the single source of truth for the "Total Registrations" / "Revenue"
+			 * figures shown on the Event Lists, Analytics and Sales Report screens, so every
+			 * page reports the same numbers and always includes custom-payment orders.
+			 *
+			 *  - tickets  = SUM(ea_ticket_qty)          (a booking of 3 tickets counts as 3)
+			 *  - revenue  = SUM(ea_ticket_order_amount) (price x qty per line)
+			 *  - lines    = number of attendee/booking rows
+			 *
+			 * @param string $start_date 'Y-m-d H:i:s' or '' for no lower bound.
+			 * @param string $end_date   'Y-m-d H:i:s' or '' for no upper bound.
+			 * @param int    $event_id   Limit to one event (ea_event_id), 0 = all events.
+			 * @return array{tickets:int,revenue:float,lines:int}
+			 */
+			public static function registration_stats( $start_date = '', $end_date = '', $event_id = 0 ) {
+				global $wpdb;
+				$statuses     = self::paid_order_statuses();
+				$status_place = implode( ',', array_fill( 0, count( $statuses ), '%s' ) );
+
+				$joins  = '';
+				$where  = array( "p.post_type = 'mep_events_attendees'", "p.post_status = 'publish'" );
+				$params = array();
+
+				$joins   .= " INNER JOIN {$wpdb->postmeta} st ON st.post_id = p.ID AND st.meta_key = 'ea_order_status' ";
+				$where[]  = "st.meta_value IN ($status_place)";
+				$params   = array_merge( $params, $statuses );
+
+				if ( $event_id ) {
+					$joins   .= " INNER JOIN {$wpdb->postmeta} ev ON ev.post_id = p.ID AND ev.meta_key = 'ea_event_id' ";
+					$where[]  = 'ev.meta_value = %d';
+					$params[] = $event_id;
+				}
+				if ( $start_date ) {
+					$where[]  = 'p.post_date >= %s';
+					$params[] = $start_date;
+				}
+				if ( $end_date ) {
+					$where[]  = 'p.post_date <= %s';
+					$params[] = $end_date;
+				}
+
+				$sql = "SELECT
+						COALESCE( SUM( CAST( qty.meta_value AS DECIMAL(20,2) ) ), 0 ) AS tickets,
+						COALESCE( SUM( CAST( amt.meta_value AS DECIMAL(20,2) ) ), 0 ) AS revenue,
+						COUNT( DISTINCT p.ID ) AS line_count
+					FROM {$wpdb->posts} p
+					{$joins}
+					LEFT JOIN {$wpdb->postmeta} qty ON qty.post_id = p.ID AND qty.meta_key = 'ea_ticket_qty'
+					LEFT JOIN {$wpdb->postmeta} amt ON amt.post_id = p.ID AND amt.meta_key = 'ea_ticket_order_amount'
+					WHERE " . implode( ' AND ', $where );
+
+				$row = $wpdb->get_row( $wpdb->prepare( $sql, $params ) );
+
+				return array(
+					'tickets' => $row ? (int) $row->tickets : 0,
+					'revenue' => $row ? (float) $row->revenue : 0.0,
+					'lines'   => $row ? (int) $row->line_count : 0,
+				);
+			}
 			//==========================//
 			public static function get_upcoming_date_time( $event_id, $all_dates = [], $all_times = [] ) {
 				$up_coming_date='';


### PR DESCRIPTION
…tive)

The Event Lists, Analytics and Sales Report pages each counted registrations and revenue differently, and several excluded native (custom-payment) orders when WooCommerce was active — so every page showed a different number.

Add one canonical, payment-source-agnostic total in MPWEM_Functions:

  - paid_order_statuses()  — the paid ea_order_status set (configured seat-reserved statuses + partially-paid + native "completed").
  - registration_stats($start,$end,$event_id) — counted from the mep_events_attendees records that BOTH WooCommerce and native checkout create: tickets = SUM(ea_ticket_qty) (a booking of 3 tickets = 3), revenue = SUM(ea_ticket_order_amount). Optional date range + event scope.

Wire the headline figures to it:

  - Event Lists: "Total Registrations" (all-time) and "Revenue This Month" / monthly registrations now use registration_stats(). The old WooCommerce-orders-only counting (which dropped native orders and counted orders, not tickets) is gone.
  - Analytics: the attendee collector is now source-agnostic (filters by paid ea_order_status, counts qty + ea_ticket_order_amount, no longer skips native attendees), and the summary cards use registration_stats() so they match the other pages.

Result: for the same date range every page reports identical totals and always includes both WooCommerce and custom-payment bookings.