### PR TITLE
Fix event date showing as January 1, 1970 in WooCommerce cart/checkout

### DIFF
--- a/inc/MPWEM_Functions.php
+++ b/inc/MPWEM_Functions.php
@@ -44,7 +44,7 @@
 					$url_date = isset( $_GET['date'] ) ? sanitize_text_field( wp_unslash( $_GET['date'] ) ) : null;
 					$url_date_2 = isset( $_GET['date_time'] ) ? sanitize_text_field( wp_unslash( $_GET['date_time'] ) ) : null;
 					$url_date=$url_date?:$url_date_2;
-					$url_date=$url_date ? date( 'Y-m-d H:i', strtotime( $url_date ) ) : '';
+					$url_date=$url_date ? date( 'Y-m-d H:i', $url_date ) : '';
 					$date_format = MPWEM_Global_Function::check_time_exit_date( $url_date ) ? 'Y-m-d H:i' : 'Y-m-d';
 					$url_date    = $url_date ? date( $date_format, strtotime($url_date) ) : '';
 					$all_dates   = MPWEM_Functions::get_dates( $event_id );


### PR DESCRIPTION
get_all_info() double-converted the ?date= URL parameter through strtotime() before formatting it. Since the sidebar's date links pass a raw Unix timestamp (via strtotime() in date_list.php), running strtotime() on that numeric string again fails and returns false, which date() silently treats as timestamp 0. That bad date then flowed into the registration form's hidden mep_event_start_date field and on into the cart/checkout.

Matches the correct pattern already used in registration_content.php, date_select.php, time_only.php, and mep_functions.php, which treat the URL value directly as a timestamp instead of re-parsing it.