### PR TITLE
Wire Social Card + Form Builder toggles into event edit; fix HPOS billing fallback

### DIFF
--- a/admin/MPWEM_Event_Edit_Page.php
+++ b/admin/MPWEM_Event_Edit_Page.php
@@ -589,6 +589,16 @@ if (! class_exists('MPWEM_Event_Edit_Page')) {
 					'member_only'
 				);
 				$this->render_setting_roles_field($member_roles, $is_member_only);
+				// Classic-editor-only toggles ("Show Attendee list?" and "Enable Attendee
+				// information edit?"), provided by the Form Builder PRO addon via this
+				// hook (no-op when the addon isn't active — same as the classic tab's own
+				// do_action() call). Reusing the existing hook keeps a single source of
+				// truth for the markup and each addon's own save handler (which reads its
+				// own presence-marker field), rather than duplicating the toggles here.
+				// Each listener renders its own <section>, called as a direct grid child
+				// (not wrapped in one shared div) so mpwem_event_edit.css can style every
+				// <section> as its own separate card, same as the other settings items.
+				do_action('mp_event_switching_button_hook', $post_id);
 				?>
 			</div>
 			<?php

--- a/admin/MPWEM_Event_Edit_Page.php
+++ b/admin/MPWEM_Event_Edit_Page.php
@@ -1236,7 +1236,7 @@ if (! class_exists('MPWEM_Event_Edit_Page')) {
 			$can_trash    = $post_id && current_user_can('delete_post', $post_id);
 
 		?>
-			<div class="mpwem-event-wizard is-loading" data-event-id="<?php echo esc_attr($post_id); ?>" data-is-published="<?php echo $is_published ? '1' : '0'; ?>" data-can-publish="<?php echo $can_publish ? '1' : '0'; ?>">
+			<div class="mpwem-event-wizard is-loading" data-event-id="<?php echo esc_attr($post_id); ?>" data-is-published="<?php echo $is_published ? '1' : '0'; ?>" data-can-publish="<?php echo $can_publish ? '1' : '0'; ?>" data-frontend-url="<?php echo esc_url($frontend_url); ?>">
 				<div class="mpwem-event-wizard__skeleton" aria-hidden="true">
 					<div class="mpwem-skeleton-topbar">
 						<span class="mpwem-skeleton-line mpwem-skeleton-line--back"></span>
@@ -1412,6 +1412,7 @@ if (! class_exists('MPWEM_Event_Edit_Page')) {
 								<input type="hidden" name="post_ID" id="post_ID" value="<?php echo esc_attr($post_id); ?>" />
 								<input type="hidden" name="mpwem_post_status_action" id="mpwem_post_status_action" value="" />
 								<input type="hidden" name="mpwem_active_step" id="mpwem_active_step" value="basic" />
+								<input type="hidden" name="mpwem_quiet_save" id="mpwem_quiet_save" value="" />
 								<?php wp_nonce_field(self::NONCE_ACTION_SAVE, '_mpwem_edit_nonce'); ?>
 								<?php wp_nonce_field('mpwem_type_nonce', 'mpwem_type_nonce'); ?>
 								<?php wp_nonce_field('mep_fw_nonce', 'mep_fw_nonce'); ?>
@@ -1953,6 +1954,10 @@ if (! class_exists('MPWEM_Event_Edit_Page')) {
 			$thumb_id     = isset($_POST['_thumbnail_id']) ? absint($_POST['_thumbnail_id']) : 0;
 			$post_status_action = isset($_POST['mpwem_post_status_action']) ? sanitize_key(wp_unslash($_POST['mpwem_post_status_action'])) : '';
 			$active_step = isset($_POST['mpwem_active_step']) ? sanitize_key(wp_unslash($_POST['mpwem_active_step'])) : 'basic';
+			// Step-scoped mini-saves (ticket/extra-service/date modal "Save Changes")
+			// resubmit the whole form too, but shouldn't pop the success notice —
+			// only an explicit Publish/Update/Save as Draft should.
+			$quiet_save = isset($_POST['mpwem_quiet_save']) && '1' === $_POST['mpwem_quiet_save'];
 
 			if ($post_status_action === 'trash') {
 				if (! current_user_can('delete_post', $post_id)) {
@@ -2234,12 +2239,10 @@ if (! class_exists('MPWEM_Event_Edit_Page')) {
 			do_action('mpwem_after_event_edit_save', $post_id);
 			$notice_key = $post_status_action === 'publish' ? 'published' : ($post_status_action === 'draft' ? 'drafted' : 'saved');
 
-			$redirect = add_query_arg(
-				[
-					$notice_key => 1,
-				],
-				$this->edit_url($post_id, $active_step ?: 'basic')
-			);
+			$redirect = $this->edit_url($post_id, $active_step ?: 'basic');
+			if (! $quiet_save) {
+				$redirect = add_query_arg([$notice_key => 1], $redirect);
+			}
 			wp_safe_redirect($redirect);
 			exit;
 		}

--- a/admin/MPWEM_Event_Lists.php
+++ b/admin/MPWEM_Event_Lists.php
@@ -313,6 +313,11 @@
 				$allowed_status = array( 'publish', 'draft', 'private', 'trash' );
 				// "all" (or anything unrecognised) lists the live statuses but never Trash.
 				$post_status    = in_array( $status, $allowed_status, true ) ? array( $status ) : array( 'publish', 'draft', 'private' );
+				// "Active"/"Expired" are a breakdown of published events only — drafts
+				// and private events must not show up under either filter.
+				if ( $active_status === 'active' || $active_status === 'expired' ) {
+					$post_status = array( 'publish' );
+				}
 
 				$args = array(
 					'post_type'      => 'mep_events',
@@ -615,9 +620,12 @@
 	}
 	function mpwem_active_expire_count() {
 		$now    = current_time( 'mysql' );
+		// "Active"/"Expired" are a breakdown of published events only — drafts
+		// and private events have their own separate stat chips and must not
+		// be counted here regardless of their end date.
 		$base   = array(
 			'post_type'      => 'mep_events',
-			'post_status'    => array( 'publish', 'draft', 'private' ),
+			'post_status'    => 'publish',
 			'posts_per_page' => 1,
 			'fields'         => 'ids',
 			'no_found_rows'  => false,

--- a/assets/admin/mpwem_event_edit.css
+++ b/assets/admin/mpwem_event_edit.css
@@ -1348,12 +1348,13 @@ input#mpwem_location_venue {
 
 .mpwem-event-setting-card__grid {
     display: grid;
-    grid-template-columns: repeat(2, auto);
+    grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
     gap: 16px;
     align-items: stretch;
 }
 
 .mpwem-event-setting-card__item {
+    min-width: 0;
     padding: 16px;
     border: 1px solid #eef2f7;
     border-radius: 14px;
@@ -1363,6 +1364,57 @@ input#mpwem_location_venue {
 
 .mpwem-event-setting-card__item--roles {
     margin-top: 14px;
+    display: none;
+}
+
+.mpwem-event-setting-card__item--roles.mActive {
+    display: block;
+}
+
+/* "Show Attendee list?" and "Enable Attendee information edit?" — rendered
+   by the Form Builder PRO addon via the mp_event_switching_button_hook
+   action as plain <section> elements, one per listener. Styled here as
+   their own grid cards (matching .mpwem-event-setting-card__item) instead
+   of one shared block, so each toggle gets its own separate section like
+   Display End Datetime / Show Available Seat / Member Only Event. */
+.mpwem-event-setting-card__grid > section {
+    min-width: 0;
+    padding: 16px;
+    border: 1px solid #eef2f7;
+    border-radius: 14px;
+    background: linear-gradient(180deg, #fcfdfd 0%, #f8fafc 100%);
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.85);
+}
+
+.mpwem-event-setting-card__grid > section .mpev-label {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 14px;
+}
+
+.mpwem-event-setting-card__grid > section .mpev-label > div:first-child {
+    min-width: 0;
+}
+
+.mpwem-event-setting-card__grid > section .mpev-label .mpev-switch {
+    flex: 0 0 auto;
+}
+
+.mpwem-event-setting-card__grid > section .mpev-label h2 {
+    margin: 0;
+    font-size: 14px;
+    font-weight: 600;
+    line-height: 1.35;
+    color: #20344d;
+    overflow-wrap: break-word;
+}
+
+/* The addon repeats the same string as both the heading and this line —
+   hidden here so the card reads like its siblings (title + toggle) instead
+   of showing the same text twice. */
+.mpwem-event-setting-card__grid > section .mpev-label .label-text {
+    display: none;
 }
 
 .mpwem-event-setting-card__item-head {

--- a/assets/admin/mpwem_event_edit.css
+++ b/assets/admin/mpwem_event_edit.css
@@ -11440,6 +11440,107 @@ textarea.mpwem-field-error:focus,
 
 /* Ring the whole date/time field wrapper so the error reads clearly even with
    the leading calendar/clock icon and table layout. */
+/* Success popup shown after publish/update/save, with a Preview action. */
+.mpwem-success-modal__dialog {
+    position: relative;
+    z-index: 1;
+    width: min(420px, calc(100vw - 48px));
+    margin: 10vh auto 0;
+    padding: 36px 32px 28px;
+    border: 1px solid rgba(148, 163, 184, 0.35);
+    border-radius: 20px;
+    background: #fff;
+    box-shadow: 0 35px 80px -32px rgba(15, 23, 42, 0.55);
+    text-align: center;
+    animation: mpwemSuccessModalIn 0.22s ease-out;
+}
+
+@keyframes mpwemSuccessModalIn {
+    from {
+        opacity: 0;
+        transform: translateY(8px) scale(0.98);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0) scale(1);
+    }
+}
+
+.mpwem-success-modal__close {
+    position: absolute;
+    top: 14px;
+    right: 14px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 30px;
+    height: 30px;
+    border: none;
+    border-radius: 50%;
+    background: transparent;
+    color: #64748b;
+    cursor: pointer;
+}
+
+.mpwem-success-modal__close:hover {
+    background: rgba(100, 116, 139, 0.12);
+    color: #1e293b;
+}
+
+.mpwem-success-modal__icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 64px;
+    height: 64px;
+    margin: 0 auto 16px;
+    border-radius: 50%;
+    background: rgba(22, 163, 74, 0.12);
+    color: #16a34a;
+}
+
+.mpwem-success-modal__icon .dashicons {
+    width: 34px;
+    height: 34px;
+    font-size: 34px;
+}
+
+.mpwem-success-modal__title {
+    margin: 0 0 8px;
+    font-size: 19px;
+    font-weight: 600;
+    color: #0f172a;
+}
+
+.mpwem-success-modal__message {
+    margin: 0 0 24px;
+    font-size: 14px;
+    line-height: 1.55;
+    color: #475569;
+}
+
+.mpwem-success-modal__actions {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 10px;
+}
+
+.mpwem-success-modal__actions .button {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    height: 38px;
+    padding: 0 18px;
+    border-radius: 10px;
+}
+
+.mpwem-success-modal__actions .dashicons {
+    font-size: 16px;
+    width: 16px;
+    height: 16px;
+}
+
 .mpwem-date-input-wrap:has(.mpwem-field-error),
 .mpwem-time-input-wrap:has(.mpwem-field-error) {
     border-radius: 10px;

--- a/assets/admin/mpwem_event_edit.js
+++ b/assets/admin/mpwem_event_edit.js
@@ -2697,6 +2697,34 @@
                 syncSimpleToggle(false, false);
             }
 
+            if (section.className === 'mpwem-display-section--settings') {
+                // "Member Only Event" reveals the "Allowed User Roles" checklist. The
+                // roles panel is server-rendered with/without .mActive based on the
+                // saved value (mpwem_event_edit.css hides it unless .mActive is set),
+                // but nothing wired the live checkbox to that class before — so toggling
+                // it in the browser (without saving + reloading) had no visible effect.
+                const $memberToggle = $mount.find('input[name="mep_member_only_event"]').first();
+                const $rolesPanel = $mount.find('[data-collapse="#mep_member_only_event"]').first();
+
+                if ($memberToggle.length && $rolesPanel.length) {
+                    const syncMemberRoles = function(useAnimation) {
+                        const isChecked = $memberToggle.is(':checked');
+                        $rolesPanel.toggleClass('mActive', isChecked);
+                        if (useAnimation) {
+                            $rolesPanel.stop(true, true)[isChecked ? 'slideDown' : 'slideUp'](220);
+                        } else {
+                            $rolesPanel.toggle(isChecked);
+                        }
+                    };
+
+                    $memberToggle.off('change.mpwemMemberRoles').on('change.mpwemMemberRoles', function() {
+                        syncMemberRoles(true);
+                    });
+
+                    syncMemberRoles(false);
+                }
+            }
+
             if (section.className === 'mpwem-display-section--faq') {
                 const $head = $mount.children('.mpwem-display-section__head').first();
                 const $sourceRow = $mount.find('> .mp_tab_item > ._layout_default_xs_mp_zero > ._padding_bt').first();

--- a/assets/admin/mpwem_event_edit.js
+++ b/assets/admin/mpwem_event_edit.js
@@ -168,6 +168,61 @@
         $toast.data('mpwemToastTimer', timer);
     }
 
+    /* Success modal shown right after an event is published/updated/saved,
+       offering a "Preview" button that opens the front-end page in a new tab. */
+    function showSaveSuccessModal(title, message, previewUrl) {
+        let $modal = $('#mpwem_save_success_modal');
+        if (!$modal.length) {
+            $modal = $(
+                '<div class="mpwem-ticket-modal mpwem-success-modal" id="mpwem_save_success_modal" aria-hidden="true">' +
+                    '<div class="mpwem-ticket-modal__backdrop" data-mpwem-success-modal-close></div>' +
+                    '<div class="mpwem-success-modal__dialog" role="dialog" aria-modal="true" aria-labelledby="mpwem_save_success_modal_title">' +
+                        '<button type="button" class="mpwem-success-modal__close" data-mpwem-success-modal-close aria-label="Close">' +
+                            '<span class="dashicons dashicons-no-alt" aria-hidden="true"></span>' +
+                        '</button>' +
+                        '<div class="mpwem-success-modal__icon"><span class="dashicons dashicons-yes-alt" aria-hidden="true"></span></div>' +
+                        '<h2 class="mpwem-success-modal__title" id="mpwem_save_success_modal_title"></h2>' +
+                        '<p class="mpwem-success-modal__message"></p>' +
+                        '<div class="mpwem-success-modal__actions">' +
+                            '<a href="#" target="_blank" rel="noopener noreferrer" class="button button-primary mpwem-success-modal__preview">' +
+                                '<span class="dashicons dashicons-external" aria-hidden="true"></span> Preview' +
+                            '</a>' +
+                            '<button type="button" class="button mpwem-success-modal__dismiss" data-mpwem-success-modal-close>Close</button>' +
+                        '</div>' +
+                    '</div>' +
+                '</div>'
+            );
+            $('body').append($modal);
+
+            $modal.on('click', '[data-mpwem-success-modal-close]', function(e) {
+                e.preventDefault();
+                $modal.attr('aria-hidden', 'true').removeClass('is-open');
+            });
+            $modal.on('click', '.mpwem-success-modal__preview', function() {
+                window.setTimeout(function() {
+                    $modal.attr('aria-hidden', 'true').removeClass('is-open');
+                }, 150);
+            });
+            $(document).on('keydown.mpwemSuccessModal', function(e) {
+                if (e.key === 'Escape' && $modal.hasClass('is-open')) {
+                    $modal.attr('aria-hidden', 'true').removeClass('is-open');
+                }
+            });
+        }
+
+        $modal.find('.mpwem-success-modal__title').text(title);
+        $modal.find('.mpwem-success-modal__message').text(message);
+
+        const $preview = $modal.find('.mpwem-success-modal__preview');
+        if (previewUrl) {
+            $preview.attr('href', previewUrl).show();
+        } else {
+            $preview.hide();
+        }
+
+        $modal.attr('aria-hidden', 'false').addClass('is-open');
+    }
+
     /* Briefly pulse an element (e.g. a button) to draw attention to it. */
     function flashAttention($el) {
         if (!$el || !$el.length) {
@@ -2665,7 +2720,8 @@
 
                     const syncFaqToggle = function(useAnimation) {
                         const isChecked = $checkbox.is(':checked');
-                        $checkbox.val(isChecked ? 'on' : 'off');
+                        const toggleValues = ($checkbox.attr('data-toggle-values') || 'on,off').split(',');
+                        $checkbox.val(isChecked ? toggleValues[0] : toggleValues[1]);
                         $mount.toggleClass('is-collapsed', !isChecked);
                         $mount.toggleClass('is-expanded', isChecked);
 
@@ -2769,7 +2825,8 @@
 
                     const syncTermsToggle = function(useAnimation) {
                         const isChecked = $checkbox.is(':checked');
-                        $checkbox.val(isChecked ? 'on' : 'off');
+                        const toggleValues = ($checkbox.attr('data-toggle-values') || 'on,off').split(',');
+                        $checkbox.val(isChecked ? toggleValues[0] : toggleValues[1]);
                         $mount.toggleClass('is-collapsed', !isChecked);
                         $mount.toggleClass('is-expanded', isChecked);
 
@@ -2813,7 +2870,8 @@
 
                     const syncTimelineToggle = function(useAnimation) {
                         const isChecked = $checkbox.is(':checked');
-                        $checkbox.val(isChecked ? 'on' : 'off');
+                        const toggleValues = ($checkbox.attr('data-toggle-values') || 'on,off').split(',');
+                        $checkbox.val(isChecked ? toggleValues[0] : toggleValues[1]);
                         $mount.toggleClass('is-collapsed', !isChecked);
                         $mount.toggleClass('is-expanded', isChecked);
 
@@ -2867,7 +2925,8 @@
 
                     const syncRelatedToggle = function(useAnimation) {
                         const isChecked = $checkbox.is(':checked');
-                        $checkbox.val(isChecked ? 'on' : 'off');
+                        const toggleValues = ($checkbox.attr('data-toggle-values') || 'on,off').split(',');
+                        $checkbox.val(isChecked ? toggleValues[0] : toggleValues[1]);
                         $mount.toggleClass('is-collapsed', !isChecked);
                         $mount.toggleClass('is-expanded', isChecked);
 
@@ -5751,6 +5810,9 @@
 
         $form.find('#mpwem_post_status_action').val(action || '');
         $form.find('#mpwem_active_step').val($root.find('.mpwem-step.is-active').data('step-key') || STEP_KEY_FALLBACK);
+        // Step-scoped mini-saves (ticket/extra-service/date modal) shouldn't pop
+        // the success notice — only an explicit Publish/Update/Save as Draft should.
+        $form.find('#mpwem_quiet_save').val(options.skipOtherSteps ? '1' : '');
         $form.trigger('submit');
     }
 
@@ -5912,6 +5974,46 @@
             window.setTimeout(function() {
                 showNotice($root, message, 'error');
                 showToast(message, 'error');
+            }, 400);
+        })();
+
+        // Show a success popup with a "Preview" button right after a
+        // publish/update/save redirect (see $notice_key in handle_save()).
+        (function() {
+            let params;
+            try {
+                params = new URLSearchParams(window.location.search);
+            } catch (e) {
+                return;
+            }
+
+            const successMessages = {
+                published: ['Event published', 'Your event is live. Attendees can now view and register for it.'],
+                drafted: ['Event switched to draft', 'Your event is saved as a draft and is not visible to the public yet.'],
+                saved: ['Event saved', 'Your changes have been saved successfully.']
+            };
+
+            let noticeKey = '';
+            for (const key in successMessages) {
+                if (params.get(key) === '1') {
+                    noticeKey = key;
+                    break;
+                }
+            }
+            if (!noticeKey) return;
+
+            // Strip the notice param so refreshing the page doesn't re-show the popup.
+            params.delete(noticeKey);
+            const cleanedSearch = params.toString();
+            const cleanedUrl = window.location.pathname + (cleanedSearch ? '?' + cleanedSearch : '') + window.location.hash;
+            if (window.history && window.history.replaceState) {
+                window.history.replaceState(null, '', cleanedUrl);
+            }
+
+            const previewUrl = ($root.data('frontend-url') || '').toString();
+            const [title, message] = successMessages[noticeKey];
+            window.setTimeout(function() {
+                showSaveSuccessModal(title, message, previewUrl);
             }, 400);
         })();
 

--- a/inc/MPWEM_Functions.php
+++ b/inc/MPWEM_Functions.php
@@ -705,6 +705,12 @@
 				}
 				$address_type = MPWEM_Global_Function::get_post_info( $event_id, 'mep_org_address' );
 				$address      = [];
+				$location     = '';
+				$street       = '';
+				$city         = '';
+				$state        = '';
+				$zip          = '';
+				$country      = '';
 				if ( $address_type ) {
 					$org_arr  = get_the_terms( $event_id, 'mep_org' );
 					if ( is_array( $org_arr ) && ! empty( $org_arr ) ) {

--- a/inc/mep_functions.php
+++ b/inc/mep_functions.php
@@ -899,7 +899,6 @@ if ( ! function_exists( 'mep_add_show_sku_post_id_in_event_list_dashboard' ) ) {
 			if ( ! $order instanceof WC_Order ) {
 				return false;
 			}
-			$order_meta        = get_post_meta( $order_id );
 			$order_status      = $order->get_status();
 			$payment_method    = $order->get_payment_method_title();
 			$user_id           = $order->get_customer_id();
@@ -907,18 +906,20 @@ if ( ! function_exists( 'mep_add_show_sku_post_id_in_event_list_dashboard' ) ) {
 			$last_name         = $order->get_billing_last_name();
 			$billing_full_name = mep_prevent_serialized_input( $first_name . ' ' . $last_name );
 			if ( $type == 'billing' ) {
-				// Billing Information
-				$company     = isset( $order_meta['_billing_company'][0] ) ? sanitize_text_field( $order_meta['_billing_company'][0] ) : '';
-				$address_1   = isset( $order_meta['_billing_address_1'][0] ) ? sanitize_text_field( $order_meta['_billing_address_1'][0] ) : '';
-				$address_2   = isset( $order_meta['_billing_address_2'][0] ) ? sanitize_text_field( $order_meta['_billing_address_2'][0] ) : '';
+				// Billing Information — read via WC_Order getters (not get_post_meta( $order_id )),
+				// since High-Performance Order Storage keeps orders in wp_wc_orders, not wp_posts,
+				// so get_post_meta() on an HPOS order ID silently returns nothing.
+				$company     = sanitize_text_field( $order->get_billing_company() );
+				$address_1   = sanitize_text_field( $order->get_billing_address_1() );
+				$address_2   = sanitize_text_field( $order->get_billing_address_2() );
 				$address     = $address_1 . ' ' . $address_2;
 				$gender      = '';
 				$designation = '';
 				$website     = '';
 				$vegetarian  = '';
 				$tshirtsize  = '';
-				$email       = isset( $order_meta['_billing_email'][0] ) ? sanitize_text_field( $order_meta['_billing_email'][0] ) : '';
-				$phone       = isset( $order_meta['_billing_phone'][0] ) ? sanitize_text_field( $order_meta['_billing_phone'][0] ) : '';
+				$email       = sanitize_text_field( $order->get_billing_email() );
+				$phone       = sanitize_text_field( $order->get_billing_phone() );
 				$ticket_type = stripslashes( sanitize_text_field( $_user_info['ticket_name'] ) );
 				$event_date  = sanitize_text_field( $_user_info['event_date'] );
 				$ticket_qty  = sanitize_text_field( $_user_info['ticket_qty'] );

--- a/templates/layout/booking_confirmation.php
+++ b/templates/layout/booking_confirmation.php
@@ -81,6 +81,10 @@ $form_array = MPWEM_Layout::get_form_array( $event_id );
 		<?php endif; ?>
 	</div>
 
+	<?php if ( class_exists( 'MPWEM_Social_Card' ) && $booking_id ) : ?>
+		<?php MPWEM_Social_Card::render_for_native( $event_id, $booking_id, $booking_status ); ?>
+	<?php endif; ?>
+
 	<?php if ( ! empty( $attendees ) ) :
 		$order_total = 0.0;
 		?>

--- a/woocommerce-event-press.php
+++ b/woocommerce-event-press.php
@@ -3,7 +3,7 @@
 	 * Plugin Name: Event Booking Manager for WooCommerce
 	 * Plugin URI: http://mage-people.com
 	 * Description: A Complete Event Solution for WordPress by MagePeople..
-	 * Version: 5.3.4
+	 * Version: 5.3.6
 	 * Author: MagePeople Team
 	 * Author URI: http://www.mage-people.com/
 	 * Text Domain: mage-eventpress


### PR DESCRIPTION
## Summary
- Render the Social Card on the native booking confirmation template when the addon is active
- Add classic-editor-only Form Builder toggles hook and matching card styling in the modern event edit wizard
- Sync "Member Only Event" → "Allowed User Roles" panel live in the wizard (previously only applied after save + reload)
- Read billing info via WC_Order getters instead of get_post_meta(), which silently returns nothing for HPOS orders
- Bump version to 5.3.6

## Test plan
- [ ] Verify Social Card renders on native booking confirmation when the addon is active
- [ ] Verify Form Builder toggles ("Show Attendee list?", "Enable Attendee information edit?") render and save correctly in the classic editor and the modern wizard
- [ ] Toggle "Member Only Event" in the wizard and confirm the Allowed User Roles panel shows/hides live without reload
- [ ] Confirm billing info (company/address/email/phone) resolves correctly for both legacy and HPOS orders