### PR TITLE
Fix WPScan-reported security issues: object injection, stored XSS, IDOR

### DIFF
--- a/admin/MPWEM_Event_Lists.php
+++ b/admin/MPWEM_Event_Lists.php
@@ -458,22 +458,24 @@
 			}
 			public function mpwem_quick_edit_event() {
 				// Verify nonce
-				if ( ! wp_verify_nonce( $_POST['nonce'], 'mep_nonce' ) ) {
+				if ( ! isset( $_POST['nonce'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['nonce'] ) ), 'mep_nonce' ) ) {
 					wp_send_json_error( array( 'message' => 'Security check failed' ) );
 				}
-				// Check user capabilities
-				if ( ! current_user_can( 'edit_posts' ) ) {
-					wp_send_json_error( array( 'message' => 'You do not have permission to edit events' ) );
-				}
-				$post_id = intval( $_POST['post_id'] );
-				if ( ! $post_id ) {
+				$post_id = isset( $_POST['post_id'] ) ? absint( $_POST['post_id'] ) : 0;
+				// Restrict to this plugin's own post type so the handler cannot be
+				// used to modify arbitrary posts/pages.
+				if ( ! $post_id || get_post_type( $post_id ) !== 'mep_events' ) {
 					wp_send_json_error( array( 'message' => 'Invalid event ID' ) );
+				}
+				// Check per-object edit capability, not just the generic 'edit_posts' cap.
+				if ( ! current_user_can( 'edit_post', $post_id ) ) {
+					wp_send_json_error( array( 'message' => 'You do not have permission to edit this event' ) );
 				}
 				// Update post data
 				$post_data = array(
 					'ID'          => $post_id,
-					'post_title'  => sanitize_text_field( $_POST['post_title'] ),
-					'post_status' => sanitize_text_field( $_POST['post_status'] )
+					'post_title'  => sanitize_text_field( wp_unslash( $_POST['post_title'] ) ),
+					'post_status' => sanitize_text_field( wp_unslash( $_POST['post_status'] ) )
 				);
 				$result    = wp_update_post( $post_data );
 				if ( is_wp_error( $result ) ) {

--- a/admin/settings/MPWEM_Faq_Settings.php
+++ b/admin/settings/MPWEM_Faq_Settings.php
@@ -278,7 +278,7 @@
 				$key     = isset( $_POST['key'] ) ? sanitize_text_field( wp_unslash( $_POST['key'] ) ) : '';
 				$title   = isset( $_POST['title'] ) ? sanitize_text_field( wp_unslash( $_POST['title'] ) ) : '';
 				$des     = isset( $_POST['des'] ) ? sanitize_text_field( wp_unslash( $_POST['des'] ) ) : '';
-				$content = isset( $_POST['content'] ) ? wp_kses_post( wp_unslash( $_POST['content'] ) ) : '';
+				$content = isset( $_POST['content'] ) ? mep_prevent_serialized_html_input( wp_unslash( $_POST['content'] ) ) : '';
 				if ( $post_id ) {
 					$faq_infos = get_post_meta($post_id,'mep_event_faq',true);
 					// Ensure $faq_infos is an array to prevent sizeof() error

--- a/admin/settings/MPWEM_Settings.php
+++ b/admin/settings/MPWEM_Settings.php
@@ -453,7 +453,7 @@
 						foreach ( $mep_faq_title as $key => $title ) {
 							if ( $title ) {
 								$faqs[ $key ]['mep_faq_title']   = $title;
-								$faqs[ $key ]['mep_faq_content'] = $mep_faq_content[ $key ];
+								$faqs[ $key ]['mep_faq_content'] = mep_prevent_serialized_html_input( $mep_faq_content[ $key ] );
 							}
 						}
 					}
@@ -473,7 +473,7 @@
 							if ( $title ) {
 								$faqs[ $key ]['mep_day_title']   = $title;
 								$faqs[ $key ]['mep_day_time']    = $mep_day_time[ $key ];
-								$faqs[ $key ]['mep_day_content'] = $mep_faq_content[ $key ];
+								$faqs[ $key ]['mep_day_content'] = mep_prevent_serialized_html_input( $mep_faq_content[ $key ] );
 							}
 						}
 					}

--- a/admin/settings/MPWEM_Timeline_Details.php
+++ b/admin/settings/MPWEM_Timeline_Details.php
@@ -270,7 +270,7 @@
 				$key     = isset( $_POST['key'] ) ? sanitize_text_field( wp_unslash( $_POST['key'] ) ) : '';
 				$title   = isset( $_POST['title'] ) ? sanitize_text_field( wp_unslash( $_POST['title'] ) ) : '';
 				$time    = isset( $_POST['time'] ) ? sanitize_text_field( wp_unslash( $_POST['time'] ) ) : '';
-				$content = isset( $_POST['content'] ) ? wp_kses_post( wp_unslash( $_POST['content'] ) ) : '';
+				$content = isset( $_POST['content'] ) ? mep_prevent_serialized_html_input( wp_unslash( $_POST['content'] ) ) : '';
 				if ( $post_id ) {
 					$time_line_infos = get_post_meta($post_id,'mep_event_day',true);
 					if ( ! is_array( $time_line_infos ) ) {

--- a/inc/MPWEM_Global_Function.php
+++ b/inc/MPWEM_Global_Function.php
@@ -264,7 +264,10 @@
 			}
 			public static function data_sanitize( $data ) {
 				if ( is_serialized( $data ) ) {
-					$data = unserialize( $data );
+					// allowed_classes => false prevents PHP object injection: any
+					// serialized object collapses to __PHP_Incomplete_Class instead
+					// of being instantiated.
+					$data = unserialize( $data, array( 'allowed_classes' => false ) );
 					$data = self::data_sanitize( $data );
 				} elseif ( is_string( $data ) ) {
 					$data = sanitize_text_field( stripslashes( strip_tags( $data ) ) );
@@ -634,7 +637,10 @@
 			}
 			public static function data_sanitize( $data ) {
 				if ( is_serialized( $data ) ) {
-					$data = unserialize( $data );
+					// allowed_classes => false prevents PHP object injection: any
+					// serialized object collapses to __PHP_Incomplete_Class instead
+					// of being instantiated.
+					$data = unserialize( $data, array( 'allowed_classes' => false ) );
 					$data = self::data_sanitize( $data );
 				} elseif ( is_string( $data ) ) {
 					$data = sanitize_text_field( stripslashes( strip_tags( $data ) ) );

--- a/inc/mep_functions.php
+++ b/inc/mep_functions.php
@@ -18,6 +18,24 @@ if ( ! function_exists( 'mep_prevent_serialized_input' ) ) {
 	}
 }
 
+if ( ! function_exists( 'mep_prevent_serialized_html_input' ) ) {
+	/**
+	 * Same serialized-payload guard as mep_prevent_serialized_input(), but for
+	 * rich-text fields (event timeline / FAQ content) that are allowed to keep
+	 * safe HTML, so it sanitizes with wp_kses_post() instead of sanitize_text_field().
+	 */
+	function mep_prevent_serialized_html_input( $value ) {
+		if ( ! is_string( $value ) ) {
+			return $value;
+		}
+		// Block any serialized data (prevents PHP object injection)
+		if ( is_serialized( $value ) || preg_match( '/(^|;)O:\d+:"/m', $value ) ) {
+			return '';
+		}
+		return wp_kses_post( $value );
+	}
+}
+
 if ( ! function_exists( 'mep_add_show_sku_post_id_in_event_list_dashboard' ) ) {
 	function mep_add_show_sku_post_id_in_event_list_dashboard( $actions, $post ) {
 		if ( $post->post_type === 'mep_events' ) {


### PR DESCRIPTION
Reported by the WPScan security team (Automattic/Jetpack) via researcher Yaswanth Reddy Sunkara:

- PHP Object Injection: data_sanitize() called unserialize() on postmeta strings without allowed_classes restriction, so a serialized object planted in event timeline/FAQ content (only wp_unslash()'d on save) could be instantiated on read, e.g. via the unauthenticated get_mpwem_ticket AJAX action. Now uses unserialize($data, ['allowed_classes' => false]) and blocks serialized-looking payloads at save time via a new mep_prevent_serialized_html_input() helper.

- Stored XSS: event timeline day content was saved with only wp_unslash(), no wp_kses_post(), unlike the sibling FAQ field, letting an Author-level user store a <script> payload that ran for every visitor. Now routed through wp_kses_post() via the same helper.

- IDOR / Arbitrary Post Modification: mpwem_quick_edit_event only checked the global edit_posts capability, letting a Contributor retitle or unpublish any post/page by ID. Now requires the target to be a mep_events post and checks current_user_can('edit_post', $post_id), matching the sibling handlers in the same file.