### PR TITLE
Fix PII exposure and access-control issues in new Orders/Attendee/Nat…

### DIFF
--- a/admin/MEP_Custom_Orders_Page.php
+++ b/admin/MEP_Custom_Orders_Page.php
@@ -609,7 +609,7 @@ class MEP_Custom_Orders_Page {
 		) );
 
 		foreach ( $orders as $o ) {
-			fputcsv( $out, array(
+			fputcsv( $out, array_map( array( __CLASS__, 'csv_safe_cell' ), array(
 				'#' . $o['ID'],
 				$o['source'] === 'shop_order' ? 'WooCommerce' : 'Native',
 				$o['order_status'],
@@ -620,11 +620,26 @@ class MEP_Custom_Orders_Page {
 				$o['total_raw'],
 				$o['gateway'],
 				$o['date'],
-			) );
+			) ) );
 		}
 
 		fclose( $out );
 		exit;
+	}
+
+	/**
+	 * Neutralise CSV/formula injection (CWE-1236): customer_name/phone/email come
+	 * from the unauthenticated native checkout billing form, so a cell starting
+	 * with =, +, -, @, tab or CR could be interpreted as a formula by Excel/Sheets
+	 * when an admin opens the export. Prefixing with a single quote forces those
+	 * spreadsheet apps to treat the cell as plain text.
+	 */
+	private static function csv_safe_cell( $value ) {
+		$value = (string) $value;
+		if ( isset( $value[0] ) && in_array( $value[0], array( '=', '+', '-', '@', "\t", "\r" ), true ) ) {
+			return "'" . $value;
+		}
+		return $value;
 	}
 
 	/* -----------------------------------------------------------------------

--- a/admin/MPWEM_Attendee_List.php
+++ b/admin/MPWEM_Attendee_List.php
@@ -43,7 +43,12 @@
 					'edit.php?post_type=' . $cpt,
 					__( 'Attendee List', 'mage-eventpress' ),
 					__( 'Attendee List', 'mage-eventpress' ),
-					MPWEM_Global_Function::get_admin_capability(),
+					// Deliberately not get_admin_capability(): that falls back to the bare
+					// 'edit_posts' cap (Contributor-level) when WooCommerce is inactive, and
+					// this page lists every attendee's name/email/phone across every event
+					// site-wide with no per-event ownership check. manage_options matches the
+					// sibling Event Orders page added alongside this one.
+					'manage_options',
 					'attendee_list',
 					array( $this, 'render_page' )
 				);
@@ -382,7 +387,8 @@
 				if ( ! isset( $_POST['nonce'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['nonce'] ) ), 'mpwem_admin_nonce' ) ) {
 					wp_send_json_error( 'Invalid nonce!' );
 				}
-				if ( ! current_user_can( MPWEM_Global_Function::get_admin_capability() ) ) {
+				// See passenger_menu() for why this is manage_options and not get_admin_capability().
+				if ( ! current_user_can( 'manage_options' ) ) {
 					wp_send_json_error( 'Permission denied' );
 				}
 				$args = array(

--- a/inc/MEP_Pro_Booking_Confirmation.php
+++ b/inc/MEP_Pro_Booking_Confirmation.php
@@ -21,12 +21,17 @@ if ( ! class_exists( 'MEP_Pro_Booking_Confirmation' ) ) {
 		}
 
 		public static function render( $atts ) {
-			$order_id = isset( $_GET['mep_booking_id'] ) ? absint( $_GET['mep_booking_id'] ) : 0;
-			$status   = isset( $_GET['mep_booking'] )    ? sanitize_key( $_GET['mep_booking'] ) : '';
+			$order_id = isset( $_GET['mep_booking_id'] )    ? absint( $_GET['mep_booking_id'] )                                : 0;
+			$status   = isset( $_GET['mep_booking'] )       ? sanitize_key( $_GET['mep_booking'] )                             : '';
+			$token    = isset( $_GET['mep_booking_token'] ) ? sanitize_text_field( wp_unslash( $_GET['mep_booking_token'] ) ) : '';
 
 			ob_start();
 
-			if ( ! $order_id || get_post_type( $order_id ) !== 'mep_custom_order' ) {
+			// The token ties this request to the person who placed the order — without
+			// it, mep_booking_id is a public sequential ID and anyone could page through
+			// every order to read other customers' name/email/phone/order details.
+			$stored_token = $order_id ? get_post_meta( $order_id, '_mep_booking_token', true ) : '';
+			if ( ! $order_id || get_post_type( $order_id ) !== 'mep_custom_order' || ! $stored_token || ! hash_equals( $stored_token, $token ) ) {
 				echo '<p class="mep-bc-notice mep-bc-error">' . esc_html__( 'No booking found.', 'mage-eventpress' ) . '</p>';
 				return ob_get_clean();
 			}

--- a/inc/MEP_Pro_Native_Checkout.php
+++ b/inc/MEP_Pro_Native_Checkout.php
@@ -145,6 +145,12 @@ if ( ! class_exists( 'MEP_Pro_Native_Checkout' ) ) {
 			// Store the WP user ID of the booker so user info can always be fetched fresh.
 			update_post_meta( $order_id, '_mep_user_id', get_current_user_id() );
 
+			// Random per-order secret required (alongside the order ID) to view the booking
+			// confirmation page — prevents enumerating mep_booking_id to read other
+			// customers' name/email/phone/order details (the confirmation page is public
+			// and otherwise has no ownership check).
+			update_post_meta( $order_id, '_mep_booking_token', wp_generate_password( 32, false ) );
+
 			update_post_meta( $order_id, '_mep_event_id',       $event_id );
 			update_post_meta( $order_id, '_mep_order_total',    $total );
 			update_post_meta( $order_id, '_mep_customer_name',  $billing_name );
@@ -458,8 +464,9 @@ if ( ! class_exists( 'MEP_Pro_Native_Checkout' ) ) {
 
 			return add_query_arg(
 				array(
-					'mep_booking'    => ( $order_status === 'completed' ) ? 'success' : 'pending',
-					'mep_booking_id' => $order_id,
+					'mep_booking'       => ( $order_status === 'completed' ) ? 'success' : 'pending',
+					'mep_booking_id'    => $order_id,
+					'mep_booking_token' => get_post_meta( $order_id, '_mep_booking_token', true ),
 				),
 				$base
 			);

--- a/inc/MPWEM_Booking_Confirmation.php
+++ b/inc/MPWEM_Booking_Confirmation.php
@@ -30,6 +30,24 @@ if ( ! class_exists( 'MPWEM_Booking_Confirmation' ) ) {
 
 			$booking_id = isset( $_GET['mep_booking_id'] ) ? sanitize_text_field( wp_unslash( $_GET['mep_booking_id'] ) ) : '';
 
+			// This is the fallback destination MEP_Pro_Native_Checkout::get_confirmation_url()
+			// redirects to when no dedicated confirmation page is configured, so it carries
+			// the same mep_booking_token. Deny by default: the template below looks up
+			// attendees purely by ea_order_id/ea_event_id meta match, with no ownership
+			// check of its own, so an unverified mep_booking_id (native order, WooCommerce
+			// order, or any other guessed value) must never reach it — otherwise anyone
+			// could view another customer's name/email/phone/order details by loading this
+			// same event URL with a guessed ID.
+			$token_ok = false;
+			if ( $booking_id && get_post_type( $booking_id ) === 'mep_custom_order' ) {
+				$token        = isset( $_GET['mep_booking_token'] ) ? sanitize_text_field( wp_unslash( $_GET['mep_booking_token'] ) ) : '';
+				$stored_token = get_post_meta( $booking_id, '_mep_booking_token', true );
+				$token_ok     = $stored_token && hash_equals( $stored_token, $token );
+			}
+			if ( ! $token_ok ) {
+				$booking_id = '';
+			}
+
 			require MPWEM_Functions::template_path( 'layout/booking_confirmation.php' );
 		}
 	}


### PR DESCRIPTION
…ive-Checkout code

Found during a self-review of the feature/free-attendee-list-and-custom-payment merge (PR #752), unrelated to the earlier WPScan reports:

- Unauthenticated IDOR on booking confirmation: both the [mep_booking_confirmation] shortcode page and the older banner rendered on the event page (the fallback destination when no dedicated confirmation page is configured) trusted a bare mep_booking_id from the URL with no ownership check, letting anyone enumerate order IDs to read other customers' name/email/phone/order details. Native checkout now generates a random _mep_booking_token per order, threads it through every confirmation redirect, and both display paths require it to match (deny by default) before showing any order data.

- Broken access control in the free Attendee List: menu registration and ajax_filter() gated on get_admin_capability(), which resolves to the bare edit_posts capability (Contributor-level) whenever WooCommerce is inactive. The underlying query has no per-event ownership scoping, so any Contributor could pull every attendee's name/email/phone across every event site-wide. Now requires manage_options, matching the sibling Event Orders page added in the same PR.

- CSV/formula injection in the order CSV export: customer_name/phone/ email (sourced from the unauthenticated native checkout billing form) were written into cells with no neutralization of leading =/+/-/@, letting a crafted booking plant a formula/DDE payload that runs when an admin opens the export in Excel/Sheets. Cells starting with those characters are now prefixed with a single quote before being written.