### PR TITLE
Add Review & Rating toggle to modern editor's Advanced step; fix Wait…

### DIFF
--- a/admin/MPWEM_Event_Edit_Page.php
+++ b/admin/MPWEM_Event_Edit_Page.php
@@ -465,6 +465,15 @@ if (! class_exists('MPWEM_Event_Edit_Page')) {
 
 		private function is_waitlist_addon_active(): bool
 		{
+			// The Waitlist addon now ships bundled inside mage-eventpress-pro/lib
+			// (merged from the old standalone plugin), so it no longer appears in
+			// is_plugin_active() by its old plugin file path. Detect the bundled
+			// build via a function it unconditionally defines when loaded, and
+			// keep the legacy check as a fallback for a genuine standalone install.
+			if (function_exists('mepw_get_waitlist_status')) {
+				return true;
+			}
+
 			if (! function_exists('is_plugin_active')) {
 				include_once ABSPATH . 'wp-admin/includes/plugin.php';
 			}
@@ -497,6 +506,51 @@ if (! class_exists('MPWEM_Event_Edit_Page')) {
 							</div>
 							<label class="mpwem-event-setting-card__switch">
 								<input type="checkbox" name="mep_show_waitlist" value="on" data-no-mpwem-switch="1" <?php checked($waitlist_enabled); ?> />
+								<span class="mpwem-event-setting-card__switch-ui" aria-hidden="true"></span>
+							</label>
+						</div>
+					</div>
+				</div>
+			</div>
+			<?php
+		}
+
+		private function is_review_addon_active(): bool
+		{
+			// The Review & Rating addon ships bundled inside mage-eventpress-pro/lib
+			// and only loads once WooCommerce is active (it calls wc_customer_bought_product()
+			// for the "verified purchaser" permission mode). Detect it via a function it
+			// unconditionally defines when loaded — same pattern as the Waitlist check above.
+			return function_exists('check_review_permission');
+		}
+
+		private function render_review_sidebar_option(int $post_id): void
+		{
+			if (! $this->is_review_addon_active()) {
+				return;
+			}
+
+			// Unset meta means enabled (matches merr_get_review_status()'s default in the
+			// addon), so existing events keep showing the review form until an admin
+			// explicitly turns it off.
+			$review_enabled = get_post_meta($post_id, 'mep_show_review', true) !== 'off';
+			?>
+			<div class="mpwem-display-section mpwem-display-section--review is-expanded">
+				<div class="mpwem-display-section__head">
+					<div class="mpwem-display-section__head-main">
+						<h3><?php esc_html_e('Review & Rating', 'mage-eventpress'); ?></h3>
+						<p><?php esc_html_e('Show the review form for this event when the Review & Rating addon is active.', 'mage-eventpress'); ?></p>
+					</div>
+				</div>
+				<div class="mpwem-display-section__body">
+					<div class="mpwem-event-setting-card__item">
+						<div class="mpwem-event-setting-card__item-head">
+							<div class="mpwem-event-setting-card__copy">
+								<h3><?php esc_html_e('Show Review Form', 'mage-eventpress'); ?></h3>
+								<p><?php esc_html_e('Turn this off to hide the "Write a Review" button for this event.', 'mage-eventpress'); ?></p>
+							</div>
+							<label class="mpwem-event-setting-card__switch">
+								<input type="checkbox" name="mep_show_review" value="on" data-no-mpwem-switch="1" <?php checked($review_enabled); ?> />
 								<span class="mpwem-event-setting-card__switch-ui" aria-hidden="true"></span>
 							</label>
 						</div>
@@ -1836,6 +1890,7 @@ if (! class_exists('MPWEM_Event_Edit_Page')) {
 														</div>
 													</div>
 													<?php $this->render_waitlist_sidebar_option($post_id); ?>
+													<?php $this->render_review_sidebar_option($post_id); ?>
 													<div class="mpwem-card mpwem-card--danger mpwem-card--danger-advanced" id="mpwem_advanced_danger_zone">
 														<div class="mpwem-card__head">
 															<h2><?php esc_html_e('Danger Zone', 'mage-eventpress'); ?></h2>

--- a/assets/admin/mpwem_event_edit.css
+++ b/assets/admin/mpwem_event_edit.css
@@ -4679,6 +4679,27 @@ body.mpwem-ticket-modal-open {
     color: #a16207;
 }
 
+.mpwem-display-section--review::before {
+    background: #be185d;
+}
+
+.mpwem-display-section--review .mpwem-display-section__head {
+    background: linear-gradient(180deg, #fff5f8 0%, #ffe4ec 100%);
+}
+
+/* No .mpwem-display-section__badge icon in this card, so drop the generic
+   head-main grid's 36px icon column — same fix as --waitlist above — or the
+   title gets squeezed into that narrow column and wraps one word per line. */
+.mpwem-display-section--review .mpwem-display-section__head-main {
+    grid-template-columns: minmax(0, 1fr);
+    row-gap: 6px;
+}
+
+.mpwem-display-section--review .mpwem-display-section__head p {
+    grid-column: 1;
+    margin-top: 0;
+}
+
 .mpwem-display-section--timeline::before {
     background: #2563eb;
 }


### PR DESCRIPTION
…list active-check

- Fix is_waitlist_addon_active(): detects the Waitlist addon via function_exists('mepw_get_waitlist_status') since it now ships bundled inside mage-eventpress-pro/lib and no longer registers under its old standalone plugin file path, so is_plugin_active() alone always returned false and the sidebar toggle never rendered.
- Add render_review_sidebar_option()/is_review_addon_active(), mirroring the Waitlist card, right underneath it in the Advanced (4) step's sidebar — saves through the PRO addon's new mep_show_review save_post handler (companion change in mage-eventpress-pro).
- Fix "Review & Rating" title wrapping one word per line: cards without a .mpwem-display-section__badge icon (Waitlist, and now Review) were still getting the generic 2-column head-main grid meant for icon+title layouts, squeezing the <h3> into its 36px icon column. Added the same single-column override for --review that --waitlist already had, plus a distinct accent color for the card.