### PR TITLE
Fix missing authorization in Payment Configuration save AJAX action

### DIFF
--- a/admin/settings/MPWEM_Ticket_Price_Settings.php
+++ b/admin/settings/MPWEM_Ticket_Price_Settings.php
@@ -59,7 +59,11 @@
 								<span style="font-size: 13px;"><?php esc_html_e( 'Please configure at least one Payment gateway to start selling tickets.', 'mage-eventpress' ); ?></span>
 							</div>
 							<div>
+								<?php if ( current_user_can( 'manage_options' ) ) : ?>
 								<button type="button" class="button button-primary mep-payment-settings-trigger" style="white-space: nowrap;"><?php esc_html_e( 'Configure Payments', 'mage-eventpress' ); ?></button>
+								<?php else : ?>
+								<span style="font-size: 13px; font-style: italic;"><?php esc_html_e( 'Ask a site administrator to configure a payment method.', 'mage-eventpress' ); ?></span>
+								<?php endif; ?>
 							</div>
 						</div>
 						<div class="mpwem-payment-status"
@@ -76,7 +80,9 @@
 								<span style="font-size: 13px;"><?php esc_html_e( 'Active:', 'mage-eventpress' ); ?> <span class="mpwem-payment-status__methods" style="font-weight: 600;"></span></span>
 							</div>
 							<div>
+								<?php if ( current_user_can( 'manage_options' ) ) : ?>
 								<button type="button" class="button button-secondary mep-payment-settings-trigger" style="white-space: nowrap;"><?php esc_html_e( 'Change Payment Method', 'mage-eventpress' ); ?></button>
+								<?php endif; ?>
 							</div>
 						</div>
 					</div>
@@ -107,6 +113,12 @@
 				$screen  = function_exists( 'get_current_screen' ) ? get_current_screen() : null;
 				$allowed = array( 'mep_events', 'mep_events_page_mpwem_event_edit' );
 				if ( ! $screen || ! in_array( $screen->id, $allowed, true ) ) {
+					return;
+				}
+				// Saving payment_setting_sec requires manage_options (see
+				// ajax_save_payment_settings_modal()), so there's no point rendering a
+				// modal + trigger buttons that everyone but admins can't use.
+				if ( ! current_user_can( 'manage_options' ) ) {
 					return;
 				}
 				$rendered = true;
@@ -150,6 +162,7 @@
 
 							<div class="mpwem-pm-body">
 								<div id="mep-payment-settings-form">
+									<input type="hidden" name="nonce" value="<?php echo esc_attr( wp_create_nonce( 'mep_save_payment_settings' ) ); ?>" />
 									<div id="mep-modal-tab-woo" class="mep-modal-tab-content">
 										<div class="mpwem-pm-card">
 											<h4 class="mpwem-pm-card__title"><?php esc_html_e( 'WooCommerce Payment', 'mage-eventpress' ); ?></h4>

--- a/admin/settings/global/admin_setting_panel.php
+++ b/admin/settings/global/admin_setting_panel.php
@@ -1077,7 +1077,9 @@ tr.payment_tabs_html { display: none !important; }
 
 
 			function ajax_save_payment_settings_modal() {
-				if ( ! current_user_can( 'manage_options' ) && ! current_user_can( 'edit_posts' ) ) {
+				check_ajax_referer( 'mep_save_payment_settings', 'nonce' );
+
+				if ( ! current_user_can( 'manage_options' ) ) {
 					wp_send_json_error( __( 'Permission denied.', 'mage-eventpress' ) );
 				}
 

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: magepeopleteam, aamahin
 Tags: events, event tickets, event registration, woocommerce, booking
 Requires at least: 5.3
-Stable tag: 5.3.7
+Stable tag: 5.3.8
 Tested up to: 7.0
 WC requires at least: 3.0
 WC tested up to: 10.7
@@ -286,6 +286,12 @@ Please report security bugs through the [Patchstack Vulnerability Disclosure Pro
 
 
 == Changelog ==
+
+= 5.3.8 =
+* Security Fix: Added nonce verification to the Payment Configuration save AJAX action (mep_save_payment_settings_modal), preventing forged requests from modifying payment settings.
+* Security Fix: Restricted the Payment Configuration save AJAX action to Administrators (manage_options), preventing lower-privileged roles (e.g. Contributor) from modifying site-wide payment settings.
+* Credit: Thanks to the Wordfence Threat Intelligence team for responsibly disclosing this issue.
+  25 July 2026*
 
 = 5.3.7 =
 * Security Fix: Hardened PHP Object Injection protection for event Timeline and F.A.Q. content (extended existing serialization guard and disabled class loading on unserialize).

--- a/woocommerce-event-press.php
+++ b/woocommerce-event-press.php
@@ -3,7 +3,7 @@
 	 * Plugin Name: Event Booking Manager for WooCommerce
 	 * Plugin URI: http://mage-people.com
 	 * Description: A Complete Event Solution for WordPress by MagePeople..
-	 * Version: 5.3.7
+	 * Version: 5.3.8
 	 * Author: MagePeople Team
 	 * Author URI: http://www.mage-people.com/
 	 * Text Domain: mage-eventpress
@@ -22,7 +22,7 @@
 		define('MPWEM_PLUGIN_URL', plugins_url() . '/' . plugin_basename(dirname(__FILE__)));
 	}
 	if (!defined('MPWEM_PLUGIN_VERSION')) {
-		define('MPWEM_PLUGIN_VERSION', '5.3.7');
+		define('MPWEM_PLUGIN_VERSION', '5.3.8');
 	}
 
 	// WooCommerce Fallback Stub Functions to prevent Fatal Errors when WooCommerce is inactive.


### PR DESCRIPTION
Reported by the Wordfence Threat Intelligence team:

- ajax_save_payment_settings_modal() (wp_ajax_mep_save_payment_settings_modal) had no nonce check and accepted any user with edit_posts (e.g. Contributor) as authorized to overwrite the site-wide payment_setting_sec option — WooCommerce/PayPal/Stripe enablement, checkout redirects, login-required toggle, etc. A logged-in Contributor could POST directly to admin-ajax.php and modify these settings for the entire site.

Fix:
- Added check_ajax_referer('mep_save_payment_settings', 'nonce') and a matching nonce field on the only form that calls this action (the Payment Configuration modal on the event edit screen).
- Restricted the capability check to manage_options only, since payment_setting_sec is a single global option, not scoped to the post being edited — edit_posts was never the right check for it.
- Hid the "Configure Payments" / "Change Payment Method" triggers and the modal itself for non-admins, since they can no longer save from it.

Bump version to 5.3.8 and add changelog entry.