### PR TITLE
Add opt-in setting to load frontend assets only on event pages

### DIFF
--- a/admin/settings/global/admin_setting_panel.php
+++ b/admin/settings/global/admin_setting_panel.php
@@ -1622,6 +1622,17 @@ tr.payment_tabs_html { display: none !important; }
 								)
 							),
 							array(
+								'name'    => 'mep_load_assets_only_on_event_pages',
+								'label'   => __( 'Load Event Styles/Scripts Only on Event Pages?', 'mage-eventpress' ),
+								'desc'    => __( 'Improves page speed by only loading the plugin\'s icon font, carousel, calendar and other frontend assets on pages that actually contain an event (single event, event archive, or an event shortcode/block). If an event shortcode is placed inside a widget or page builder module that this can\'t detect, select "No" or use the mpwem_force_load_frontend_assets filter.', 'mage-eventpress' ),
+								'type'    => 'select',
+								'default' => 'no',
+								'options' => array(
+									'yes' => 'Yes',
+									'no'  => 'No'
+								)
+							),
+							array(
 								'name'    => 'mep_speed_up_list_page',
 								'label'   => __( 'Speed up the Event List Page Loading?', 'mage-eventpress' ),
 								'desc'    => __( 'If your event list page is loading slowly, you can select this option to improve performance. Keep in mind that selecting this option will disable Waitlist and Seat count features. ', 'mage-eventpress' ),

--- a/assets/mage-icon/css/mage-icon.css
+++ b/assets/mage-icon/css/mage-icon.css
@@ -17,6 +17,7 @@
   src: url("../fonts/mage-icon.woff2?v=1.0.0") format("woff2"), url("../fonts/mage-icon.ttf?v=1.0.0") format("truetype"), url("../fonts/mage-icon.woff?v=1.0.0") format("woff");
   font-weight: normal;
   font-style: normal;
+  font-display: swap;
 }
 .mi {
   display: inline-block;

--- a/inc/MPWEM_Dependencies.php
+++ b/inc/MPWEM_Dependencies.php
@@ -237,7 +237,57 @@
 
 				do_action( 'add_mpwem_admin_script' );
 			}
+			/**
+			 * Gate for the whole frontend bundle (mage-icon font, Font Awesome,
+			 * Flaticon, Slick, Owl Carousel, timeline, calendar, mixitup, moment.js...).
+			 * Opt-in via settings - default stays "load on every page" so sites
+			 * relying on a shortcode placement we can't detect here (widgets,
+			 * page builders that don't store it in post_content) don't silently
+			 * lose icons/styles. Use the mpwem_force_load_frontend_assets filter
+			 * to force-load on a page this misses once the setting is enabled.
+			 */
+			public function should_load_frontend_assets() {
+				$only_on_event_pages = MPWEM_Global_Function::get_settings( 'general_setting_sec', 'mep_load_assets_only_on_event_pages', 'no' );
+				if ( $only_on_event_pages !== 'yes' ) {
+					return true;
+				}
+				if ( apply_filters( 'mpwem_force_load_frontend_assets', false ) ) {
+					return true;
+				}
+				if ( is_singular( array( 'mep_events', 'mep_event_speaker', 'mep_events_reg_form' ) )
+					|| is_post_type_archive( 'mep_events' )
+					|| is_tax( array( 'mep_cat', 'mep_org', 'mep_tag' ) ) ) {
+					return true;
+				}
+				global $post;
+				if ( $post instanceof WP_Post ) {
+					$shortcodes = array(
+						'event-list-recurring',
+						'event-list',
+						'events_list',
+						'expire-event-list',
+						'event-add-cart-section',
+						'event-city-list',
+						'event-speaker-list',
+						'event-calendar',
+						'mep-event-calendar',
+						'mep_booking_confirmation',
+					);
+					foreach ( $shortcodes as $shortcode ) {
+						if ( has_shortcode( $post->post_content, $shortcode ) ) {
+							return true;
+						}
+					}
+					if ( function_exists( 'has_block' ) && has_block( 'mage/event-list', $post ) ) {
+						return true;
+					}
+				}
+				return false;
+			}
 			public function frontend_enqueue() {
+				if ( ! $this->should_load_frontend_assets() ) {
+					return;
+				}
 				$this->global_enqueue();
 				$is_divi = function_exists('et_divi_builder_init') || defined('ET_BUILDER_PLUGIN_ACTIVE');
 				wp_enqueue_script( 'mep-mixitup-min-js', 'https://cdnjs.cloudflare.com/ajax/libs/mixitup/3.3.0/mixitup.min.js', array(), '3.3.0', true );


### PR DESCRIPTION
The icon font, Font Awesome, Flaticon, Slick, Owl Carousel, timeline, calendar, mixitup and moment.js were all enqueued unconditionally on every frontend page via wp_enqueue_scripts, not just pages that actually show an event - customer reported the 452KB mage-icon.woff2 loading site-wide and hurting page speed.

Gate the bundle behind a new "Load Event Styles/Scripts Only on Event Pages?" setting (default off, so existing sites keep today's behavior) that detects singular/archive/taxonomy event pages and the plugin's shortcodes/block in post content, with a mpwem_force_load_frontend_assets filter as an escape hatch for widget/page-builder placements it can't see.

Also add font-display: swap to the icon font so pages where it does load aren't blocked waiting on it.