### PR TITLE
Open Attendee List, Event Orders, Analytics and RSVP Responses to Sho…

### DIFF
--- a/admin/MEP_Custom_Orders_Page.php
+++ b/admin/MEP_Custom_Orders_Page.php
@@ -185,7 +185,7 @@ class MEP_Custom_Orders_Page {
 			'edit.php?post_type=mep_events',
 			__( 'Event Orders', 'mage-eventpress' ),
 			$menu_title,
-			'manage_options',
+			MPWEM_Global_Function::get_shop_manager_capability(),
 			'mep_event_orders',
 			array( __CLASS__, 'render_page' )
 		);
@@ -534,7 +534,7 @@ class MEP_Custom_Orders_Page {
 	 * -------------------------------------------------------------------- */
 	public static function ajax_filter() {
 		check_ajax_referer( 'mep_orders_nonce', 'nonce' );
-		if ( ! current_user_can( 'manage_options' ) ) {
+		if ( ! current_user_can( MPWEM_Global_Function::get_shop_manager_capability() ) ) {
 			wp_send_json_error( 'Unauthorized', 403 );
 		}
 
@@ -577,7 +577,7 @@ class MEP_Custom_Orders_Page {
 	 * -------------------------------------------------------------------- */
 	public static function export_csv() {
 		check_ajax_referer( 'mep_orders_nonce', 'nonce' );
-		if ( ! current_user_can( 'manage_options' ) ) {
+		if ( ! current_user_can( MPWEM_Global_Function::get_shop_manager_capability() ) ) {
 			wp_die( 'Unauthorized', 403 );
 		}
 
@@ -647,7 +647,7 @@ class MEP_Custom_Orders_Page {
 	 * -------------------------------------------------------------------- */
 	public static function ajax_update_status() {
 		check_ajax_referer( 'mep_orders_nonce', 'nonce' );
-		if ( ! current_user_can( 'manage_options' ) ) {
+		if ( ! current_user_can( MPWEM_Global_Function::get_shop_manager_capability() ) ) {
 			wp_send_json_error( 'Unauthorized', 403 );
 		}
 
@@ -727,7 +727,7 @@ class MEP_Custom_Orders_Page {
 	 * -------------------------------------------------------------------- */
 	public static function ajax_resend_pdf() {
 		check_ajax_referer( 'mep_orders_nonce', 'nonce' );
-		if ( ! current_user_can( 'manage_options' ) ) {
+		if ( ! current_user_can( MPWEM_Global_Function::get_shop_manager_capability() ) ) {
 			wp_send_json_error( array( 'message' => __( 'Unauthorized', 'mage-eventpress' ) ), 403 );
 		}
 
@@ -770,7 +770,7 @@ class MEP_Custom_Orders_Page {
 	 * -------------------------------------------------------------------- */
 	public static function ajax_bulk_status() {
 		check_ajax_referer( 'mep_orders_nonce', 'nonce' );
-		if ( ! current_user_can( 'manage_options' ) ) {
+		if ( ! current_user_can( MPWEM_Global_Function::get_shop_manager_capability() ) ) {
 			wp_send_json_error( 'Unauthorized', 403 );
 		}
 
@@ -817,7 +817,7 @@ class MEP_Custom_Orders_Page {
 	 * -------------------------------------------------------------------- */
 	public static function ajax_add_note() {
 		check_ajax_referer( 'mep_orders_nonce', 'nonce' );
-		if ( ! current_user_can( 'manage_options' ) ) {
+		if ( ! current_user_can( MPWEM_Global_Function::get_shop_manager_capability() ) ) {
 			wp_send_json_error( 'Unauthorized', 403 );
 		}
 
@@ -884,7 +884,7 @@ class MEP_Custom_Orders_Page {
 	 * -------------------------------------------------------------------- */
 	public static function ajax_delete_note() {
 		check_ajax_referer( 'mep_orders_nonce', 'nonce' );
-		if ( ! current_user_can( 'manage_options' ) ) {
+		if ( ! current_user_can( MPWEM_Global_Function::get_shop_manager_capability() ) ) {
 			wp_send_json_error( 'Unauthorized', 403 );
 		}
 

--- a/admin/MPWEM_Attendee_List.php
+++ b/admin/MPWEM_Attendee_List.php
@@ -46,9 +46,10 @@
 					// Deliberately not get_admin_capability(): that falls back to the bare
 					// 'edit_posts' cap (Contributor-level) when WooCommerce is inactive, and
 					// this page lists every attendee's name/email/phone across every event
-					// site-wide with no per-event ownership check. manage_options matches the
-					// sibling Event Orders page added alongside this one.
-					'manage_options',
+					// site-wide with no per-event ownership check. get_shop_manager_capability()
+					// opens it to Shop Manager (matches the sibling Event Orders page) without
+					// going that low.
+					MPWEM_Global_Function::get_shop_manager_capability(),
 					'attendee_list',
 					array( $this, 'render_page' )
 				);
@@ -390,8 +391,8 @@
 				if ( ! isset( $_POST['nonce'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['nonce'] ) ), 'mpwem_admin_nonce' ) ) {
 					wp_send_json_error( 'Invalid nonce!' );
 				}
-				// See passenger_menu() for why this is manage_options and not get_admin_capability().
-				if ( ! current_user_can( 'manage_options' ) ) {
+				// Matches the capability passenger_menu() registers the page under.
+				if ( ! current_user_can( MPWEM_Global_Function::get_shop_manager_capability() ) ) {
 					wp_send_json_error( 'Permission denied' );
 				}
 				$args = array(

--- a/admin/MPWEM_RSVP_Responses.php
+++ b/admin/MPWEM_RSVP_Responses.php
@@ -20,7 +20,7 @@ if ( ! class_exists( 'MPWEM_RSVP_Responses' ) ) {
 				'edit.php?post_type=mep_events',
 				__( 'RSVP Responses', 'mage-eventpress' ),
 				__( 'RSVP Responses', 'mage-eventpress' ),
-				'manage_options',
+				MPWEM_Global_Function::get_shop_manager_capability(),
 				'event-rsvp-responses',
 				array( $this, 'render_page' )
 			);
@@ -268,7 +268,7 @@ if ( ! class_exists( 'MPWEM_RSVP_Responses' ) ) {
 
 		public function ajax_checkin_rsvp() {
 			check_ajax_referer( 'mep_rsvp_nonce', 'nonce' );
-			if ( ! current_user_can( 'manage_options' ) ) {
+			if ( ! current_user_can( MPWEM_Global_Function::get_shop_manager_capability() ) ) {
 				wp_send_json_error( 'Permission denied.' );
 			}
 
@@ -284,7 +284,7 @@ if ( ! class_exists( 'MPWEM_RSVP_Responses' ) ) {
 
 		public function ajax_bulk_action() {
 			check_ajax_referer( 'mep_rsvp_nonce', 'nonce' );
-			if ( ! current_user_can( 'manage_options' ) ) {
+			if ( ! current_user_can( MPWEM_Global_Function::get_shop_manager_capability() ) ) {
 				wp_send_json_error( 'Permission denied.' );
 			}
 
@@ -309,7 +309,7 @@ if ( ! class_exists( 'MPWEM_RSVP_Responses' ) ) {
 		}
 
 		public function export_csv() {
-			if ( isset( $_GET['mep_export_rsvps'] ) && current_user_can( 'manage_options' ) ) {
+			if ( isset( $_GET['mep_export_rsvps'] ) && current_user_can( MPWEM_Global_Function::get_shop_manager_capability() ) ) {
 				
 				$args = array(
 					'post_type'      => 'mep_rsvp_responses',

--- a/admin/mep_analytics.php
+++ b/admin/mep_analytics.php
@@ -19,7 +19,7 @@ function mep_event_analytics_admin_menu() {
 		'edit.php?post_type=mep_events',
 		__( 'Analytics', 'mage-eventpress' ),
 		'<span style="color:#32c1a4">Analytics</span>',
-		'manage_options',
+		MPWEM_Global_Function::get_shop_manager_capability(),
 		'mep_event_analytics_page',
 		'mep_event_analytics_page'
 	);
@@ -508,6 +508,9 @@ function mep_analytics_collect_from_orders( $events, $start_ts, $end_ts, $status
 add_action( 'wp_ajax_mep_get_analytics_data', 'mep_get_analytics_data' );
 function mep_get_analytics_data() {
 	check_ajax_referer( 'mep_analytics_nonce', 'nonce' );
+	if ( ! current_user_can( MPWEM_Global_Function::get_shop_manager_capability() ) ) {
+		wp_send_json_error( 'Unauthorized', 403 );
+	}
 
 	// Parse inputs
 	$start_date = isset( $_POST['start_date'] ) ? sanitize_text_field( wp_unslash( $_POST['start_date'] ) ) : date( 'Y-m-d', strtotime( '-30 days' ) );
@@ -578,6 +581,9 @@ function mep_get_analytics_data() {
 add_action( 'wp_ajax_mep_export_analytics_csv', 'mep_export_analytics_csv' );
 function mep_export_analytics_csv() {
 	check_ajax_referer( 'mep_analytics_nonce', 'nonce' );
+	if ( ! current_user_can( MPWEM_Global_Function::get_shop_manager_capability() ) ) {
+		wp_die( 'Unauthorized', 403 );
+	}
 
 	$start_date = isset( $_POST['start_date'] ) ? sanitize_text_field( wp_unslash( $_POST['start_date'] ) ) : date( 'Y-m-d', strtotime( '-30 days' ) );
 	$end_date   = isset( $_POST['end_date'] ) ? sanitize_text_field( wp_unslash( $_POST['end_date'] ) ) : date( 'Y-m-d' );

--- a/inc/MPWEM_Global_Function.php
+++ b/inc/MPWEM_Global_Function.php
@@ -304,6 +304,17 @@
 			public static function get_admin_capability(): string {
 				return self::has_woocommerce() ? 'manage_woocommerce' : 'edit_posts';
 			}
+			/**
+			 * For pages that should open up to WooCommerce's Shop Manager role
+			 * (Attendee List, Event Orders, Analytics, RSVP Responses, Booking
+			 * Calendar, the Attendee hub) without going as low as edit_posts.
+			 * Shop Manager only exists because of WooCommerce, so falling back
+			 * to manage_options when WooCommerce is inactive keeps these
+			 * Administrator-only rather than accidentally locking everyone out.
+			 */
+			public static function get_shop_manager_capability(): string {
+				return self::has_woocommerce() ? 'manage_woocommerce' : 'manage_options';
+			}
 			public static function price_convert_raw( $price ) {
 				if ( ! self::has_woocommerce() ) {
 					$price = wp_strip_all_tags( $price );


### PR DESCRIPTION
…p Manager

These pages were all hard-coded to manage_options (Administrator only). Add MPWEM_Global_Function::get_shop_manager_capability() - manage_woocommerce when WooCommerce is active (Administrator + Shop Manager), falling back to manage_options when it isn't (Shop Manager only exists via WooCommerce anyway, so this keeps admins from being locked out on sites without it).

Apply it to each page's add_submenu_page() call and to the matching current_user_can() checks in their AJAX/action handlers, so a Shop Manager who can now see the menu doesn't hit "Permission denied" on every action inside it. Also added an explicit capability check to Analytics' two AJAX handlers, which previously had none.