### PR TITLE
fix(description): always render the full event description

### DIFF
--- a/templates/layout/description.php
+++ b/templates/layout/description.php
@@ -16,23 +16,14 @@
 	$description_title         = is_array($single_event_setting_sec) && array_key_exists( 'mep_event_hide_description_title', $single_event_setting_sec ) ? $single_event_setting_sec['mep_event_hide_description_title'] : 'no';
 	$post_content              = get_post_field( 'post_content', $event_id );
 	if ( $post_content ) {
-		$word_count   = str_word_count( wp_strip_all_tags( $post_content ) );
-		$has_readmore = $word_count > 200;
-		$details_class = 'mpwem_details' . ( $has_readmore ? ' mpwem_details--has-readmore' : '' );
 		?>
-        <div class="<?php echo esc_attr( $details_class ); ?>"<?php echo $has_readmore ? ' data-readmore-words="200"' : ''; ?>>
+        <div class="mpwem_details">
 			<?php if ( $description_title == 'no' ): ?>
                 <h2 class="_mb"><?php esc_html_e( 'Event  Description', 'mage-eventpress' ); ?></h2>
 			<?php endif; ?>
-            <div class="mpwem_details_content mp_wp_editor<?php echo $has_readmore ? ' is-collapsed' : ''; ?>">
+            <div class="mpwem_details_content mp_wp_editor">
 				<?php the_content(); ?>
             </div>
-			<?php if ( $has_readmore ) : ?>
-                <button type="button" class="mpwem_details_readmore" aria-expanded="false">
-                    <span class="mpwem_details_readmore__more"><?php esc_html_e( 'Read More', 'mage-eventpress' ); ?></span>
-                    <span class="mpwem_details_readmore__less"><?php esc_html_e( 'Read Less', 'mage-eventpress' ); ?></span>
-                </button>
-			<?php endif; ?>
         </div>
 		<?php
 	}


### PR DESCRIPTION
### Problem

On a single event page the description was cut off after 200 words and a **Read More** toggle was shown.

`templates/layout/description.php` counted the words in `post_content` and, past 200, added `mpwem_details--has-readmore` to the wrapper plus a Read More / Read Less button.

The truncation is not a CSS clip. `mpwemInitDetailsReadMore()` in `assets/frontend/mpwem_script.js` rebuilds the content with a shortened copy:

```js
$content.html(shortHtml).addClass('is-collapsed');
```

so everything past the 200th word is removed from the DOM until the visitor clicks. Hiding the button with CSS would therefore have left the description permanently truncated — the markup had to stop flagging read-more.

### Change

Render the description in full and drop the read-more markup:

- no more `$word_count` / `$has_readmore` branch
- wrapper is always a plain `mpwem_details`
- content div no longer gets `is-collapsed`
- Read More / Read Less button removed

### Notes

- The read-more JS and the "Description Read More" CSS block are left in place but are now inert, since `mpwem_details--has-readmore` is never emitted. Happy to strip them in a follow-up if you'd rather not carry dead code.
- The **speaker role** read-more (`mep-default-speaker__role`) is a separate feature and is untouched.
- Reported by MyattsField Vineyards, where a 420-word event description was being cut in half. Verified on their live site: full description renders, no `mpwem_details--has-readmore`, `data-readmore-words`, `is-collapsed` or button in the output.

### Testing

- Event with a description over 200 words → renders in full, no button.
- Event with a description under 200 words → unchanged (it never had a button).
- "Hide description title" setting still respected in both cases.
